### PR TITLE
Compilation fails on ArchLinux 64 bit

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ justenoughharfbuzz_la_LIBADD = $(HARFBUZZ_LIBS) $(FREETYPE_LIBS) $(FONTCONFIG_LI
 justenoughlibtexpdf_la_SOURCES = justenoughlibtexpdf.c
 justenoughlibtexpdf_la_LDFLAGS = -module -avoid-version -shared
 justenoughlibtexpdf_la_CFLAGS = -I.. $(LIBPNG_INCLUDES) $(ZLIB_INCLUDES) $(LIBPAPER_INCLUDES) $(LUA_INCLUDE) $(FREETYPE_CFLAGS)
-justenoughlibtexpdf_la_LIBADD = ../libtexpdf/.libs/libtexpdf.a $(FREETYPE_LIBS) $(LIBPNG_LIBS) $(ZLIB_LIBS) $(LIBPAPER_LIBS)
+justenoughlibtexpdf_la_LIBADD = ../libtexpdf/.libs/libtexpdf.la $(FREETYPE_LIBS) $(LIBPNG_LIBS) $(ZLIB_LIBS) $(LIBPAPER_LIBS)
 
 all-local: $(core_LTLIBRARIES)
 	cp .libs/justenoughharfbuzz.so .libs/justenoughlibtexpdf.so ../core


### PR DESCRIPTION
On my system the compilation fails with the following error:

```
LC_ALL=C make
Making all in libtexpdf
make[1]: Entering directory '/home/nicola/sandbox/sile/libtexpdf'
make  all-am
make[2]: Entering directory '/home/nicola/sandbox/sile/libtexpdf'
make[2]: Leaving directory '/home/nicola/sandbox/sile/libtexpdf'
make[1]: Leaving directory '/home/nicola/sandbox/sile/libtexpdf'
Making all in src
make[1]: Entering directory '/home/nicola/sandbox/sile/src'
/bin/sh ../libtool  --tag=CC   --mode=link gcc -I..     -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz  -O2 -Wall -module -avoid-version -shared  -o justenoughlibtexpdf.la -rpath /usr/local/share/sile/core justenoughlibtexpdf_la-justenoughlibtexpdf.lo ../libtexpdf/.libs/libtexpdf.a -lfreetype     

*** Warning: Linking the shared library justenoughlibtexpdf.la against the
*** static library ../libtexpdf/.libs/libtexpdf.a is not portable!
libtool: link: gcc -shared  -fPIC -DPIC  .libs/justenoughlibtexpdf_la-justenoughlibtexpdf.o   ../libtexpdf/.libs/libtexpdf.a -lfreetype  -O2   -Wl,-soname -Wl,justenoughlibtexpdf.so -o .libs/justenoughlibtexpdf.so
/usr/bin/ld: ../libtexpdf/.libs/libtexpdf.a(libtexpdf_la-fontmap.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
../libtexpdf/.libs/libtexpdf.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
Makefile:443: recipe for target 'justenoughlibtexpdf.la' failed
make[1]: *** [justenoughlibtexpdf.la] Error 1
make[1]: Leaving directory '/home/nicola/sandbox/sile/src'
Makefile:507: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
```

I had to link against the `.la` object instead to be able to complete the build.
