### PR TITLE
Put core libraries in /usr/lib/sile instead of /usr/share/sile.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,12 +88,16 @@ AS_IF([test "$backend" = "pangocairo"],
 adl_RECURSIVE_EVAL(["${datadir}/${PACKAGE}"], [SILE_PATH])
 AC_DEFINE_UNQUOTED([SILE_PATH],["${SILE_PATH}"],[Path for SILE packages and classes])
 
+adl_RECURSIVE_EVAL(["${libdir}/${PACKAGE}"], [SILE_LIB_PATH])
+AC_DEFINE_UNQUOTED([SILE_LIB_PATH],["${SILE_LIB_PATH}"],[Path for SILE libraries])
+
 AC_MSG_NOTICE([Configuring with $backend backend])
 AM_CONDITIONAL([HARFBUZZLIBTEXPDF], [test "$backend" = "harfbuzz"])
 AC_SUBST([backend])
 AC_SUBST([HARFBUZZ_CFLAGS])
 AC_SUBST([HARFBUZZ_LIBS])
 AC_SUBST([SILE_PATH])
+AC_SUBST([SILE_LIB_PATH])
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_CONFIG_FILES([sile], [chmod +x sile])
 

--- a/sile.in
+++ b/sile.in
@@ -1,7 +1,7 @@
 #!@LUA@
 package.path = (os.getenv("SILE_PATH") and
 os.getenv("SILE_PATH").."/?.lua" or "") .. ';?.lua;@SILE_PATH@/?.lua;@SILE_PATH@/lua-libraries/?.lua;@SILE_PATH@/lua-libraries/?/init.lua;lua-libraries/?.lua;lua-libraries/?/init.lua;' .. package.path 
-package.cpath = package.cpath .. ";core/?.so;@SILE_PATH@/core/?.so;"
+package.cpath = package.cpath .. ";core/?.so;@SILE_LIB_PATH@/?.so;"
 SILE = require("core/sile")
 io.stdout:setvbuf 'no'
 SILE.parseArguments()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,5 @@
 if HARFBUZZLIBTEXPDF
-coredir = $(pkgdatadir)/core
-core_LTLIBRARIES = justenoughharfbuzz.la justenoughlibtexpdf.la
+pkglib_LTLIBRARIES = justenoughharfbuzz.la justenoughlibtexpdf.la
 justenoughharfbuzz_la_SOURCES = justenoughharfbuzz.c
 justenoughharfbuzz_la_LDFLAGS = -module -avoid-version -shared
 justenoughharfbuzz_la_CFLAGS = $(HARFBUZZ_CFLAGS) $(FREETYPE_CFLAGS) $(FONTCONFIG_CFLAGS) $(LUA_INCLUDE)


### PR DESCRIPTION
/usr/share should only contain architecture independant data.
This is a packaging requirement for various distributions.