### PR TITLE
Show some font info when loadfont fails.

### DIFF
--- a/core/libtexpdf-output.lua
+++ b/core/libtexpdf-output.lua
@@ -43,6 +43,7 @@ SILE.outputters.libtexpdf = {
     lastkey = SILE.font._key(options)
     font = SILE.font.cache(options)
     f = pdf.loadfont(font)
+    if f< 0 then SU.error("Font loading error for "..options) end
     font = f
   end,
   drawImage = function (src, x,y,w,h)


### PR DESCRIPTION
When trying to compile the sile documentation, I was getting some weird errors:
```
libtexpdf:fatal: Invalid font: -1 (324)
``` 
Not really useful. 
After some investigation, the error comes from the fact the libtexpdf can not load a pfa version of the Utopia font.
So, I searched for Utopia references in the source without finding anything.

After some more code exploration, I found out that the default font is Gentium and that  if it's not installed, fontconfig resolves it in some cases as the Utopia font.

So, I think, loadfont should report something with the original font name if the a matching font cannot be loaded.

Aside of that, the documentation should probably list Gentium as a sile dependency. (And I should make that requirement in my fedora packages).
