### PR TITLE
Initialize pdf_files to allow the libtexpdf outputter to use PDF files as images.

### DIFF
--- a/src/justenoughlibtexpdf.c
+++ b/src/justenoughlibtexpdf.c
@@ -24,6 +24,7 @@ int pdf_init (lua_State *L) {
   mediabox.lly = 0.0;
   mediabox.urx = w;
   mediabox.ury = height;
+  texpdf_files_init();
   texpdf_init_fontmaps();
   texpdf_doc_set_mediabox(p, 0, &mediabox);
   texpdf_add_dict(p->info,
@@ -48,7 +49,8 @@ int pdf_finish(lua_State *L) {
   ASSERT(p);
   texpdf_close_document(p);
   texpdf_close_device  ();
-  texpdf_close_fontmaps();    
+  texpdf_close_fontmaps();
+  texpdf_files_close();
   return 0;
 }
 


### PR DESCRIPTION
This is allows me to include a pdf file using `SILE.outputter.drawImage` .
It's a first step towards pdf image support; currently, pdf files cannot be included a using the image package (imagesize lacks pdf support).
