### PR TITLE
In case of libtexpdf outputter, use it to compute imagesize.

### DIFF
--- a/core/cairo-output.lua
+++ b/core/cairo-output.lua
@@ -3,6 +3,7 @@ local cairo = lgi.cairo
 local pango = lgi.Pango
 local fm = lgi.PangoCairo.FontMap.get_default()
 local pango_context = lgi.Pango.FontMap.create_context(fm)
+local imagesize = SILE.require("imagesize")
 
 if (not SILE.outputters) then SILE.outputters = {} end
 
@@ -58,6 +59,13 @@ SILE.outputters.cairo = {
     p:set_matrix(matrix)
     cr:paint()
     cr:restore()
+  end,
+  imageSize = function (src)
+    local box_width,box_height, err = imagesize.imgsize(src)imagesize.imgsize(src)
+    if not box_width then
+      SU.error(err.." loading image")
+    end
+    return box_width, box_height
   end,
   moveTo = function (x,y)
     move(cr, x,y)

--- a/core/libtexpdf-output.lua
+++ b/core/libtexpdf-output.lua
@@ -49,6 +49,10 @@ SILE.outputters.libtexpdf = {
   drawImage = function (src, x,y,w,h)
     pdf.drawimage(src, x, y, w, h)
   end,
+  imageSize = function (src)
+    local llx, lly, urx, ury = pdf.imagebbox(src)
+    return (urx-llx), (ury-lly)
+  end,
   moveTo = function (x,y)
     cursorX = x
     cursorY = SILE.documentState.paperSize[2] - y

--- a/core/podofo-output.lua
+++ b/core/podofo-output.lua
@@ -1,4 +1,5 @@
 local pdf = require("podofo");
+local imagesize = SILE.require("imagesize")
 if (not SILE.outputters) then SILE.outputters = {} end
 
 local document
@@ -54,6 +55,13 @@ SILE.outputters.podofo = {
     SILE.fontCache[lastkey] = nil
   end,
   drawPNG = function (src, x,y,w,h)
+  end,
+  imageSize = function (src)
+    local box_width,box_height, err = imagesize.imgsize(src)imagesize.imgsize(src)
+    if not box_width then
+      SU.error(err.." loading image")
+    end
+    return box_width, box_height
   end,
   moveTo = function (x,y)
     cursorX = x

--- a/packages/image.lua
+++ b/packages/image.lua
@@ -1,13 +1,9 @@
-local imagesize = SILE.require("imagesize")
 SILE.registerCommand("img", function(options, content)
   SU.required(options, "src", "including image file")
   local width =  SILE.parseComplexFrameDimension(options.width or 0,"w") or 0 
   local height = SILE.parseComplexFrameDimension(options.height or 0,"h") or 0
   local src = options.src
-  local box_width,box_height,err = imagesize.imgsize(src)
-  if not box_width then
-    SU.error(err.." loading image")
-  end
+  local box_width,box_height = SILE.outputter.imageSize(src)
   local sx, sy = 1,1
   if width > 0 or height > 0 then
     sx = width > 0 and box_width / width

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@ justenoughharfbuzz_la_LDFLAGS = -module -avoid-version -shared
 justenoughharfbuzz_la_CFLAGS = $(HARFBUZZ_CFLAGS) $(FREETYPE_CFLAGS) $(FONTCONFIG_CFLAGS) $(LUA_INCLUDE)
 justenoughharfbuzz_la_LIBADD = $(HARFBUZZ_LIBS) $(FREETYPE_LIBS) $(FONTCONFIG_LIBS)
 
-justenoughlibtexpdf_la_SOURCES = justenoughlibtexpdf.c
+justenoughlibtexpdf_la_SOURCES = justenoughlibtexpdf.c imagebbox.c
 justenoughlibtexpdf_la_LDFLAGS = -module -avoid-version -shared
 justenoughlibtexpdf_la_CFLAGS = -I.. $(LIBPNG_INCLUDES) $(ZLIB_INCLUDES) $(LIBPAPER_INCLUDES) $(LUA_INCLUDE) $(FREETYPE_CFLAGS)
 justenoughlibtexpdf_la_LIBADD = ../libtexpdf/.libs/libtexpdf.la $(FREETYPE_LIBS) $(LIBPNG_LIBS) $(ZLIB_LIBS) $(LIBPAPER_LIBS)

--- a/src/imagebbox.c
+++ b/src/imagebbox.c
@@ -1,0 +1,64 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <libtexpdf/libtexpdf.h>
+
+int get_pdf_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury) {
+  pdf_obj* page;
+  long page_no = 1;
+  long count;
+  pdf_rect bbox;
+  pdf_file* pf = texpdf_open(NULL, f);
+  if (!pf) {
+    return -1;
+  }
+
+  page = texpdf_doc_get_page(pf, page_no, &count, &bbox, NULL);
+
+  texpdf_close(pf);
+
+  if (!page)
+    return -1;
+
+  texpdf_release_obj(page);
+
+  *llx = bbox.llx;
+  *lly = bbox.lly;
+  *urx = bbox.urx;
+  *ury = bbox.ury;
+  return 0;
+}
+
+int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury) {
+  long width, height;
+  double xdensity, ydensity;
+
+  if (texpdf_check_for_bmp(f)) {
+    if(texpdf_bmp_get_bbox(f, &width, &height, &xdensity, &ydensity) < 0) {
+      return -1;
+    }
+  } else if (texpdf_check_for_jpeg(f)) {
+    if(texpdf_jpeg_get_bbox(f, &width, &height, &xdensity, &ydensity) < 0) {
+      return -1;
+    }
+  } else if (texpdf_check_for_jp2(f)) {
+    if(texpdf_jp2_get_bbox(f, &width, &height, &xdensity, &ydensity) < 0) {
+      return -1;
+    }
+  } else if (texpdf_check_for_png(f)) {
+    if(texpdf_png_get_bbox(f, &width, &height, &xdensity, &ydensity) < 0) {
+      return -1;
+    }
+  } else if (texpdf_check_for_pdf(f)) {
+    return get_pdf_bbox(f, llx, lly, urx, ury);
+  } else {
+    return -1;
+  }
+
+  *llx = 0;
+  *lly =0;
+  *urx = width * xdensity;
+  *ury = height * ydensity;
+  return 0;
+}
+
+

--- a/src/justenoughlibtexpdf.c
+++ b/src/justenoughlibtexpdf.c
@@ -178,6 +178,34 @@ int pdf_drawimage(lua_State *L) {
   return 0;
 }
 
+extern int get_image_bbox(FILE* f, double* llx, double* lly, double* urx, double* ury);
+
+int pdf_imagebbox(lua_State *L) {
+  const char* filename = luaL_checkstring(L, 1);
+  double llx = 0;
+  double lly = 0;
+  double urx = 0;
+  double ury = 0;
+
+  FILE* f = MFOPEN(filename, FOPEN_RBIN_MODE);
+  if (!f) {
+    return luaL_error(L, "Image file not found %s", filename);
+  }
+
+  if ( get_image_bbox(f, &llx, &lly, &urx, &ury) < 0 ) {
+    MFCLOSE(f);
+    return luaL_error(L, "Invalid image file %s", filename);
+  }
+
+  MFCLOSE(f);
+
+  lua_pushnumber(L, llx);
+  lua_pushnumber(L, lly);
+  lua_pushnumber(L, urx);
+  lua_pushnumber(L, ury);
+  return 4;
+}
+
 int pdf_transform(lua_State *L) {
   pdf_tmatrix matrix;
   double a = luaL_checknumber(L, 1);
@@ -228,6 +256,7 @@ static const struct luaL_Reg lib_table [] = {
   {"setrule", pdf_setrule},
   {"setcolor", pdf_setcolor},
   {"drawimage", pdf_drawimage},
+  {"imagebbox", pdf_imagebbox},
   {"colorpop", pdf_colorpop},
   {"colorpush", pdf_colorpush},
   {"setmatrix", pdf_transform},


### PR DESCRIPTION
This enables pdf images support in the libtexpdf case.
Other outputters fallback to the imagesize package.