### PR TITLE
Do not silent lua errors

### DIFF
--- a/sile.in
+++ b/sile.in
@@ -24,8 +24,12 @@ if unparsed and unparsed[1] then
     end
   end
   p,e = pcall(function() SILE.readFile(unparsed[1]) end)
-  if not p and e:match(": interrupted!") then
-    SILE.outputter:finish()
+  if not p then
+    if e:match(": interrupted!") then
+      SILE.outputter:finish()
+    else
+      io.write("\nError detected:\n"..e.."\n")
+    end
     os.exit(1)
   end
   if SILE.preamble then SILE.documentState.documentClass:finish() end


### PR DESCRIPTION
It's easier to debug the class file you're working on, if errors are shown when you test it.
