### PR TITLE
Tools and chordmode

### DIFF
--- a/packages/chordmode.lua
+++ b/packages/chordmode.lua
@@ -1,0 +1,72 @@
+local tools = SILE.require("packages/tools").exports
+
+local function addChords(text, content)
+  local start, stop, chord, char
+  local index = 1
+  local chordText = nil
+  local result = {}
+  local strlen = string.len(text)
+  
+  repeat
+    start, stop, chord = string.find(text, "<([^>]+)>", index)
+    if stop==nil then
+      table.insert(result, string.sub(text, index))
+      index = strlen+1
+    else
+      -- Parse a new chord
+      if (start-index) > 1 then
+        table.insert(result, string.sub(text, index, start - 1 ))
+      end
+      index = stop + 1
+      start, stop, char = string.find(text, "([<\n])", index)
+      if stop==nil then
+        chordText = string.sub(text, index)
+        index = strlen+1
+      else
+        if(char=='<') then 
+          start = start - 1
+        end
+        chordText = string.sub(text, index, start)
+        index = start
+      end
+      table.insert(result, tools.createCommand(content.pos, content.col, content.line, "ch", {name=chord}, chordText))
+    end
+  until index > strlen
+
+  return result
+end
+
+SILE.registerCommand("ch", function(options, content)
+  local chordBox = SILE.Commands["hbox"]({}, {options.name})
+  SILE.typesetter.state.nodes[#(SILE.typesetter.state.nodes)] = nil
+
+  -- Temporary hard coded values should be configurable
+  local offset = SILE.toPoints("2.5", "mm", "h")
+  local chordLineHeight = SILE.toPoints("4", "mm", "h")
+  local chordBoxHeight = chordLineHeight + 2 * offset
+  local heightOffset = chordLineHeight - chordBox.height + offset
+  local width = chordBox.width.length
+
+  SILE.typesetter:pushHbox({
+    height = chordBoxHeight,
+    outputYourself = function (self, typesetter, line)
+      typesetter.frame:moveY(-heightOffset)
+      SILE.outputter:pushColor({r=0.5, g=0, b=0})
+    end
+  });
+  table.insert(SILE.typesetter.state.nodes, chordBox)
+  SILE.typesetter:pushHbox({
+    height = chordBoxHeight,
+    outputYourself = function (self, typesetter, line)
+      typesetter.frame:moveY(heightOffset)
+      typesetter.frame:moveX(-width)
+      SILE.outputter:popColor()
+    end
+  });
+  SILE.process(content)
+end, "Insert a a chord name above the text")
+
+SILE.registerCommand("chordmode", function(options, content)
+  SILE.process(tools.transformContent(content, addChords))
+end, "Transform embedded chords to 'ch' commands")
+

--- a/packages/tools.lua
+++ b/packages/tools.lua
@@ -1,0 +1,47 @@
+local function tableInsertAll(t, values)
+  local i, n
+  for i, n in ipairs(values) do
+    table.insert(t, n)
+  end
+end
+
+local function transformContent(content, transformFunction)
+  local k, v
+  local newContent = {}
+
+  for k,v in pairs(content) do 
+    if type(k) == "number" then
+      if type(v) == "string" then
+        local nc = transformFunction(v, content)
+        if type(nc) == "table" then
+          tableInsertAll(newContent, nc)
+        else
+          table.insert(newContent, nc)
+        end
+      else 
+        table.insert(newContent, transformContent(v, transformFunction))
+      end
+    else
+      newContent[k] = v
+    end
+  end
+  return newContent
+end
+
+local function createCommand(pos, col, line, tag, attr, content)
+  local result = {content}
+  result.col = col
+  result.line = line
+  result.pos = pos
+  result.attr = attr
+  result.tag = tag
+  result.id = "command"
+  return result
+end
+
+return {
+  exports = {
+    createCommand = createCommand,
+    transformContent = transformContent
+  }
+}


### PR DESCRIPTION
Here is the chordmode code split in:
- tools for the generic text manipulation
- chordmode that uses the tools package to place the text above the current line.

Simple tools package example that defines an uppercase command that uses the transformContent function:
```
\begin[papersize=a4,class=plain]{document}
\script[src=packages/color]
\begin{script}
local tools = SILE.require("packages/tools").exports
SILE.registerCommand("uppercase", function(options, content)
  SILE.process(tools.transformContent(content, string.upper))
end, "Typeset the enclosed text as uppercase")
\end{script}

First line of text

\begin{uppercase}
This one should be uppercase 
  \color[color=#000090]{blue}, 
  \color[color=#900000]{red}, 
  \color[color=#009000]{green}.
\end{uppercase}
\end{document}
```

This is rendered as: 
![tools-example](https://cloud.githubusercontent.com/assets/838332/6767380/fd55a4fc-d02c-11e4-8a73-34d94b0ded41.png)

Note how the transformContent function traverse the whole content tree to transform all contained text.

