### PR TITLE
Add a package to typeset chord name above text.

### DIFF
--- a/examples/chordmode.sil
+++ b/examples/chordmode.sil
@@ -1,0 +1,25 @@
+\begin[papersize=a4,class=songbook]{document}
+
+\script[src=packages/chordmode]
+
+\begin{chordmode}
+
+  I've be<G>en a wild rover for many's a <C>year
+
+  And I <G>spent all me <D7>money on whiskey and <G>beer
+
+  But now I'm returning with gold in great <C>store
+
+  And I <G>never will <D7>play The Wild Rover no <G>more.
+
+  Complex line <Am7>b<C5dim>d<Em>
+
+  Line without any chord
+
+  <F> starts with a chord.
+
+  ends with a chord<G>
+
+\end{chordmode}
+
+\end{document}

--- a/packages/chordmode.lua
+++ b/packages/chordmode.lua
@@ -1,0 +1,105 @@
+local inputfilter = SILE.require("packages/inputfilter").exports
+
+local function addChords(text, content)
+  local result = {}
+  local chordName = nil
+  local currentText = ""
+  local process = nil
+  local processText, processChordName, processChordText
+
+  local function insertChord()
+    table.insert(result, inputfilter.createCommand(
+      content.pos, content.col, content.line,
+      "ch", {name=chordName}, currentText
+    ))
+    chordName = nil
+  end
+
+  local function insertText()
+    if (#currentText>0) then table.insert(result, currentText) end
+    currentText = ""
+  end
+
+  local function ignore(separator)
+    currentText = currentText .. separator
+  end
+
+  processText = {
+    ["<"] = function(separator)
+      insertText()
+      process = processChordName
+    end
+  }
+
+  processChordName = {
+    [">"] = function(separator)
+      chordName = currentText
+      currentText = ""
+      process = processChordText
+    end
+  }
+
+  processChordText = {
+    ["<"] = function(separator)
+      insertChord()
+      currentText = ""
+      process = processChordName
+    end;
+    ["\n"] = function(separator)
+      insertChord()
+      currentText = separator
+      process = processText
+    end
+  }
+  process = processText
+
+  for token in SU.gtoke(text, "[<\n>]") do
+    if(token.string) then
+      currentText = currentText .. token.string
+    else
+      (process[token.separator] or ignore)(token.separator)
+    end
+  end
+
+  if (chordName ~= nil) then
+    insertChord()
+  else
+    insertText()
+  end
+  return result
+end
+
+SILE.registerCommand("ch", function(options, content)
+  local chordBox = SILE.Commands["hbox"]({}, {options.name})
+  SILE.typesetter.state.nodes[#(SILE.typesetter.state.nodes)] = nil
+
+  -- Temporary hard coded values should be configurable
+  local offset = SILE.toPoints("2.5", "mm", "h")
+  local chordLineHeight = SILE.toPoints("4", "mm", "h")
+  local chordBoxHeight = chordLineHeight + 2 * offset
+  local heightOffset = chordLineHeight - chordBox.height + offset
+  local width = chordBox.width.length
+
+  SILE.typesetter:pushHbox({
+    height = chordBoxHeight,
+    outputYourself = function (self, typesetter, line)
+      typesetter.frame:moveY(-heightOffset)
+      SILE.outputter:pushColor({r=0.5, g=0, b=0})
+    end
+  });
+  table.insert(SILE.typesetter.state.nodes, chordBox)
+  SILE.typesetter:pushHbox({
+    height = chordBoxHeight,
+    outputYourself = function (self, typesetter, line)
+      typesetter.frame:moveY(heightOffset)
+      typesetter.frame:moveX(-width)
+      SILE.outputter:popColor()
+    end
+  });
+  SILE.process(content)
+end, "Insert a a chord name above the text")
+
+SILE.registerCommand("chordmode", function(options, content)
+  SILE.process(inputfilter.transformContent(content, addChords))
+end, "Transform embedded chords to 'ch' commands")
+


### PR DESCRIPTION
Here is a new version of the chordmode package using SU.gtoke for text parsing and a kind of state machine to process the found tokens. Let me know what you think about that part.

The ``\ch`` command implementation is still buggy (See the line starting with "Complex line" in the example) and as you suggested should be implemented on top of some simple TeX like commands (to be added in another package).

I am working to fix this.

