### PR TITLE
Add converters to prepare files before inclusion by SILE.

### DIFF
--- a/examples/conv-test.lua
+++ b/examples/conv-test.lua
@@ -1,0 +1,13 @@
+#!/usr/bin/env lua
+local output = io.open(arg[2], "w+")
+output:write("\\begin{document}\n")
+for line in io.lines(arg[1]) do
+  if(string.sub(line, 1, 2)=="= ") then
+    output:write("\\center{"..string.sub(line, 3).."}")
+  else
+    output:write(line)
+  end
+  output:write("\n")
+end
+output:write("\\end{document}\n")
+output:close()

--- a/examples/conv-test.txt
+++ b/examples/conv-test.txt
@@ -1,0 +1,3 @@
+= Centered text
+
+Left aligned text 

--- a/examples/converters.sil
+++ b/examples/converters.sil
@@ -1,0 +1,12 @@
+\begin[papersize=a4,class=plain]{document}
+
+\script[src=packages/converters]
+
+First line of text
+
+\converters:register[from=.txt, to=.sil, command=examples/conv-test.lua "$SOURCE" "$TARGET"]
+
+\converters:include[src=examples/conv-test.txt]
+
+\end{document}
+

--- a/examples/converters.sil
+++ b/examples/converters.sil
@@ -1,12 +1,18 @@
 \begin[papersize=a4,class=plain]{document}
 
+\script[src=packages/image]
 \script[src=packages/converters]
 
 First line of text
 
 \converters:register[from=.txt, to=.sil, command=examples/conv-test.lua "$SOURCE" "$TARGET"]
+\converters:register[from=.svg, to=.pdf, command=inkscape -A "$TARGET" "$SOURCE"]
 
-\converters:include[src=examples/conv-test.txt]
+\img[src=examples/smiley.svg, width=50px]
+
+\include[src=examples/conv-test.txt]
+
+\img[src=examples/smiley.svg, width=100px]
 
 \end{document}
 

--- a/examples/smiley.svg
+++ b/examples/smiley.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="smiley.svg"
+   viewBox="0 0 13.546667 13.546666">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6"
+     inkscape:cx="26.729734"
+     inkscape:cy="24.205066"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     units="mm"
+     inkscape:window-width="1280"
+     inkscape:window-height="958"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-283.45333)">
+    <ellipse
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffff00;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28222224;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3333"
+       cx="6.7733335"
+       cy="290.22665"
+       rx="6.6322222"
+       ry="6.6322227" />
+    <circle
+       cy="287.858"
+       cx="4.3290877"
+       id="ellipse4143"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.28222224;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       r="0.42333335" />
+    <circle
+       r="0.42333335"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.28222224;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="circle4145"
+       cx="9.2175789"
+       cy="287.858" />
+    <path
+       id="ellipse4147"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28222224;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       sodipodi:type="arc"
+       sodipodi:cx="6.7733335"
+       sodipodi:cy="291.33539"
+       sodipodi:rx="2.0965083"
+       sodipodi:ry="2.0965083"
+       sodipodi:start="0.52359878"
+       sodipodi:end="2.6179939"
+       d="M 8.588963,292.38364 A 2.0965083,2.0965083 0 0 1 6.7733335,293.4319 2.0965083,2.0965083 0 0 1 4.9577041,292.38364"
+       sodipodi:open="true" />
+  </g>
+</svg>

--- a/packages/converters.lua
+++ b/packages/converters.lua
@@ -48,6 +48,7 @@ local checkConverters = function(source)
       return applyConverter(source, converter)
     end
   end
+  return source -- No conversion needed.
 end
 
 SILE.registerCommand("converters:register", function(o, c)

--- a/packages/converters.lua
+++ b/packages/converters.lua
@@ -1,0 +1,71 @@
+local lfs = require('lfs')
+
+SILE.scratch.converters = {}
+
+local register = function(sourceExt, targetExt, command)
+  table.insert(SILE.scratch.converters, {
+    sourceExt = sourceExt,
+    targetExt = targetExt,
+    command = command
+  })
+end
+
+local applyConverter = function(source, converter)
+  local extLen = string.len(converter.sourceExt)
+  local targetFile = string.sub(source, 1, -extLen-1) .. converter.targetExt
+
+  local sourceTime = lfs.attributes(source, "modification")
+
+  if (sourceTime==nil) then
+    return nil -- source not found
+  end
+
+  local targetTime = lfs.attributes(targetFile, "modification")
+  if((targetTime~=nil) and (targetTime>sourceTime)) then
+    return targetFile -- already converted
+  end
+
+  command = string.gsub(converter.command, "%$(%w+)", {
+    SOURCE = source,
+    TARGET = targetFile
+  })
+
+  if(os.execute(command)) then
+    return targetFile
+  else
+    return nil
+  end
+end
+
+local checkConverters = function(source)
+  for _, converter in ipairs(SILE.scratch.converters) do
+    local extLen = string.len(converter.sourceExt)
+    if ((string.len(source) > extLen) and
+        (string.sub(source, -extLen) == converter.sourceExt)) then
+      return applyConverter(source, converter)
+    end
+  end
+end
+
+SILE.registerCommand("converters:register", function(o, c)
+  register(o.from, o.to, o.command)
+end)
+
+SILE.registerCommand("converters:check", function(o, c)
+  checkConverters(o.source)
+end)
+
+SILE.registerCommand("converters:include", function(o, c)
+  local result = checkConverters(o.src)
+  if(result~=nil) then
+    SILE.call("include", {src=result})
+  end
+end)
+
+return {
+  exports = {
+    register= register,
+    check= checkConverters
+  }
+}
+


### PR DESCRIPTION
This is a first idea of a file conversion package for SILE.
It allows you to register a converter based on file extensions, and a conversion command.

This package adds an enhanced \include command that convert a file before inclusion.
When called with a source file, it's extension is checked and the file is converted if a matching converter is found. Then the generated file is included instead of the original one.

To avoid conversion on each execution, I added a dependency on LuaFileSystem to check if the source file is newer than the target one. If needed, I can make it optional.

In fact, I have the same problem as #44 : I'm working with svg file and need to convert them to pdf using inkscape before using them in SILE. So, if I provides SILE with an enhanced \image command that uses the converter, I can avoid using a Makefile to prepare my document.

Let me know what you think about that idea.
