### PR TITLE
Ignore dirty state of the libtexpdf submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libtexpdf"]
 	path = libtexpdf
 	url = https://github.com/simoncozens/libtexpdf.git
+	ignore = dirty


### PR DESCRIPTION
There mere act of running ./bootstrap.sh make the submodule dirty
(regenerating auto generated files and so on), which is uninteresting so
better just ignore it.