### PR TITLE
 \setLTR and \setRTL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ ltmain.sh
 subfiles.mk
 
 sile
+config.log
+core/justenoughharfbuzz.so
+core/justenoughlibtexpdf.so

--- a/classes/plain.lua
+++ b/classes/plain.lua
@@ -12,6 +12,14 @@ plain.endPage = function(self)
   return SILE.baseClass.endPage(self)
 end
 
+plain.newPage = function(self)
+  local f = SILE.baseClass.newPage(self)
+  print("setting direction to "..SILE.scratch.bidi["currentDir"])
+  f.direction = SILE.scratch.bidi["currentDir"]
+  f:newLine()
+  return f
+end
+
 SILE.registerCommand("noindent", function ( options, content )
   SILE.settings.set("current.parindent", SILE.nodefactory.zeroGlue)
   SILE.process(content)
@@ -145,5 +153,18 @@ SILE.registerCommand("vbox", function (options,c)
   end)
   return vbox
 end, "Compiles all the enclosed horizontal-mode material into a single hbox")
+
+SILE.scratch.bidi = { currentDir = "LTR" }
+
+SILE.registerCommand("setRTL", function(options, content)
+  SILE.scratch.bidi["currentDir"] = "RTL"
+  SILE.typesetter.frame.direction = "RTL"
+  SILE.typesetter.frame:newLine()
+end)
+
+SILE.registerCommand("setLTR", function(options, content)
+  SILE.scratch.bidi["currentDir"] = "LTR"
+  SILE.typesetter.frame.direction = "LTR"  
+end)
 
 return plain;

--- a/core/frame.lua
+++ b/core/frame.lua
@@ -93,9 +93,11 @@ end
 
 function SILE.framePrototype:newLine()
   self.state.cursorX = self.direction == "RTL" and self:right() or self:left()
+  print(self.direction == "RTL" and "Setting Right" or "Setting Left")
 end
 
 function SILE.framePrototype:init()
+  print "init new frame"
   self.state = {
     cursorY = self:top(),
     totals = { height= 0, pastTop = false }


### PR DESCRIPTION
This is a first attempt at adding support for bidirectional text across multiple frames (see #77) . It seems to have at least one serious bug. Compare [intended output][1] to [actual output][2]. Notice the header on top of the second page just vanishes unexpectedly. I can’t quite figure out why that is the case.

[1]: https://dl.dropboxusercontent.com/u/953/site_assets/urdu_sile.pdf
[2]: https://dl.dropboxusercontent.com/u/953/urdu_assg.pdf

Some other points for discussion:

* The idea of using `\setLTR` and `\setRTL` for switching the direction of paragraphs is borrowed from TeX’s [bidi][3] package
* Given SILE is intended to be a next-gen typesetting package, bidi support should be built-in to one of the default document classes, probably `plain`. We should not need to import a package to get bidi support.
* There should be support for typesetting short RTL text inside LTR paragraphs as well (and vice versa), something equivalent to the TeX bidi pacakages `\LRE` and `\RLE`

[3]: https://www.ctan.org/pkg/bidi?lang=en

Please let me know what you think of this approach, or if you have any alternative suggestions.