### PR TITLE
Fix trailing comment at the end of the document.

### DIFF
--- a/core/inputs-texlike.lua
+++ b/core/inputs-texlike.lua
@@ -19,7 +19,7 @@ SILE.inputs.TeXlike.parser = function (_ENV)
   document = V("stuff") * (-1 + E("Unexpected character at end of input"))
   text = (anything + C(WS))^1 / function(...) return table.concat({...}, "") end
   stuff = Cg(V"environment" + 
-    ((P("%") * (1-lpeg.S("\r\n"))^0 * lpeg.S("\r\n")) /function () return "" end) -- Don't bother telling me about comments
+    ((P("%") * (1-lpeg.S("\r\n"))^0 * lpeg.S("\r\n")^-1) /function () return "" end) -- Don't bother telling me about comments
     + V("text") + V"bracketed_stuff" + V"command")^0
   bracketed_stuff = P"{" * V"stuff" * (P"}" + E("} expected"))
   command =((P("\\")-P("\\begin")) * Cg(myID, "tag") * Cg(parameters,"attr") * V"bracketed_stuff"^0)-P("\\end{")


### PR DESCRIPTION
The processing currently fails at this one-line document: `\begin[papersize=a4]{document}\end{document}%` (no new line at the end). This patch fixes that.
