### PR TITLE
fix Turkish hyphenation rules

### DIFF
--- a/languages/tr.lua
+++ b/languages/tr.lua
@@ -34,7 +34,8 @@ SILE.hyphenator.languages["tr"].patterns =
 "1v1",
 "1y1",
 "1z1",
--- prevent e-cek at end of word
+-- prevent a-cak/e-cek at end of word
+"2a2cak.",
 "2e2cek.",
 -- prohibit hyphen before pair of consonants
 -- many pairs generated here are impossible anyway


### PR DESCRIPTION
The white paper published in TUG on Turkish hyphenation specifically
mentions the special -ecek case and similar suffixes in the context of
dealing with trailing two letter suffixes. The code, however, only
matches the two letter variants with a special case for -ecek, but
overlooks -acak which is a grammatically identical variant with the same
issues.

http://www.tug.org/TUGboat/Articles/tb09-1/tb20mackay.pdf

I also submitted this tweak to the author of the upstream LaTeX package
on CPAN where these rules originated. I don't know how slow moving that
fix will be or if there will eventually be a re-import or not, but until
then I don't see a reason not to patch it here too.