### PR TITLE
update ignore list with all relics of current build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 tests/*.actual
 tests/*.pdf
+tests/*.toc
+examples/*.pdf
+examples/*.toc
 # http://www.gnu.org/software/automake
 
 Makefile.in
@@ -29,6 +32,7 @@ m4/lt~obsolete.m4
 .libs
 *.lo
 *.la
+src/*.o
 AUTHORS
 COPYING
 INSTALL


### PR DESCRIPTION
This is some minor housekeeping but the git ignore rules aren't catching some of the build relics. This just makes it a touch easier to keep track of what is going on during development.

I noticed somebody else had started to fix this as well so I kept their commit to credit them. Incidentally their [other in-progress feature branch](https://github.com/deepakjois/sile/tree/exp) could then be rebased for an easier comparison of what is being contributed.