### PR TITLE
make dependency on luafilesystem explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_install:
  - cd ../
  - sudo luarocks install lpeg
  - sudo luarocks install luaexpat
+ - sudo luarocks install luafilesystem
  - sudo luarocks install lua_cliargs 2.3-3
  - sudo luarocks install busted
 script:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You also need to install the following Lua libraries using [luarocks][] (downloa
 
 * `lpeg`
 * `luaexpat`
+* `luafilesystem`
 * `lgi` (required for Pango-Cairo only)
 
 Once your dependencies are installed, run

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,7 @@ AX_LUA_LIBS
 # Check for Lua modules
 AX_LUA_MODULE([lpeg], [lpeg])
 AX_LUA_MODULE([lxp], [luaexpat])
+AX_LUA_MODULE([lfs], [luafilesystem])
 
 AS_IF([test "$backend" = "pangocairo"],
   [AX_LUA_MODULE([lgi],[lgi])],

--- a/documentation/sile.sil
+++ b/documentation/sile.sil
@@ -246,6 +246,7 @@ libraries if they’re not already installed:
 
 \listitem{\code{luarocks install lpeg}}
 \listitem{\code{luarocks install luaexpat}}
+\listitem{\code{luarocks install luafilesystem}}
 
 Once you have these requirements in place, you should then be able to unpack
 the file that you downloaded from SILE’s home page, change to that directory,


### PR DESCRIPTION
The converters package has a dependency on the lfs module. See 65f39d49
for how it uses it. I realize this will only come up for people that use
that package, but I think it should be expected that the install
process will get everything setup to use any of the core packages that
ship with SILE at will. This lua library seems to be pretty widely used
so I don't see a problem with calling it out as a dependency. This is
something that package managers especially need to be made aware of.