### PR TITLE
update regression test to match a4ae37f

### DIFF
--- a/tests/balanced.expected
+++ b/tests/balanced.expected
@@ -797,7 +797,7 @@ Mx 	213.88398
 T	88 74 79 70 84 76 74 79 84 15 1761	(wineskins.”)
 Mx 	170.62378
 My 	365.70583
-Set font 	Linux Biolinum O;18;800.0;normal;normal;;LTR
+Set font 	Linux Biolinum O;18;800;normal;normal;;LTR
 T	36 73 66 81 85 70 83	(Chapter)
 Mx 	239.65178
 T	20	(3)


### PR DESCRIPTION
Fixes #125

This particular test went the opposite way as the other ones you fixed. In d0dd50f you forced five digit accuracy, in a4ae37f you rounded. Both make sense for the circumstances, but I had saved all the tests based on the default Lua 5.3 behavior. This updates the test to be the way you normalized the output.