### PR TITLE
Use relative paths for includes

### DIFF
--- a/core/inputs-common.lua
+++ b/core/inputs-common.lua
@@ -9,6 +9,10 @@ SILE.inputs.common = {
       end
     end
 
+    -- Prepend the dirname of the input file to the Lua search path
+    local dirname = SILE.masterFilename:match("(.-)[^%/]+$")
+    package.path = dirname.."?;"..dirname.."?.lua;"..package.path
+
     if not SILE.outputFilename and SILE.masterFilename then
       SILE.outputFilename = string.gsub(SILE.masterFilename,"%..-$", "").. ".pdf"
     end

--- a/core/inputs-common.lua
+++ b/core/inputs-common.lua
@@ -9,8 +9,8 @@ SILE.inputs.common = {
       end
     end
 
-    if not SILE.outputFilename and SILE.masterFileName then
-      SILE.outputFilename = string.gsub(SILE.masterFileName,"%..-$", "").. ".pdf"
+    if not SILE.outputFilename and SILE.masterFilename then
+      SILE.outputFilename = string.gsub(SILE.masterFilename,"%..-$", "").. ".pdf"
     end
     local ff = SILE.documentState.documentClass:init()
     SILE.typesetter:init(ff)

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -64,7 +64,7 @@ SILE.require = function(d)
 end
 
 SILE.parseArguments = function()
-local parser = std.optparse ("This is SILE "..SILE.version..[[
+local parser = std.optparse ("SILE "..SILE.version..[[
 
  Usage: sile [options] file.sil|file.xml
 

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -59,7 +59,6 @@ SILE.init = function()
 end
 
 SILE.require = function(d)
-  -- path?
   return require(d)
 end
 
@@ -171,7 +170,8 @@ function SILE.resolveFile(fn)
   if file_exists(fn) then return fn end
   if file_exists(fn..".sil") then return fn..".sil" end
 
-  for k in SU.gtoke(os.getenv("SILE_PATH"), ";") do
+  local dirname = SILE.masterFilename:match("(.-)[^%/]+$")
+  for k in SU.gtoke(dirname..";"..tostring(os.getenv("SILE_PATH")), ";") do
     if k.string then
       local f = std.io.catfile(k.string, fn)
       if file_exists(f) then return f end

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -66,36 +66,37 @@ end
 SILE.parseArguments = function()
 local parser = std.optparse ("SILE "..SILE.version..[[
 
- Usage: sile [options] file.sil|file.xml
+Usage: sile [options] file.sil|file.xml
 
- The SILE typesetter.
+The SILE typesetter reads a single input file in either SIL or XML format to
+generate an output in PDF format. The output will be writted to the same name
+as the input file with the extention changed to .pdf.
 
- Options:
+Options:
 
-   -d, --debug=VALUE        debug SILE's operation
-   -b, --backend=VALUE      choose between libtexpdf/pangocairo backends
-   -I, --include=[FILE]     include a class or SILE file before
-                            processing main file
-   -e, --evaluate=VALUE     evaluate some Lua code before processing file
-       --version            display version information, then exit
-       --help               display this help, then exit
+  -b, --backend=VALUE      choose between libtexpdf/pangocairo backends
+  -d, --debug=VALUE        debug SILE's operation
+  -e, --evaluate=VALUE     evaluate some Lua code before processing file
+  -I, --include=[FILE]     include a class or SILE file before processing input
+      --help               display this help, then exit
+      --version            display version information, then exit
 ]])
 
   parser:on ('--', parser.finished)
   _G.unparsed, _G.opts = parser:parse(_G.arg)
   SILE.debugFlags = {}
-  if opts.debug then
-    for k,v in ipairs(std.string.split(opts.debug, ",")) do SILE.debugFlags[v] = 1 end
-  end
   if opts.backend then
     SILE.backend = opts.backend
   end
-  if opts.include then
-    SILE.preamble = opts.include
+  if opts.debug then
+    for k,v in ipairs(std.string.split(opts.debug, ",")) do SILE.debugFlags[v] = 1 end
   end
   if opts.evaluate then
     SILE.dolua,err = loadstring(opts.evaluate)
     if err then SU.error(err) end
+  end
+  if opts.include then
+    SILE.preamble = opts.include
   end
 end
 

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -77,6 +77,7 @@ Options:
   -b, --backend=VALUE      choose between libtexpdf/pangocairo backends
   -d, --debug=VALUE        debug SILE's operation
   -e, --evaluate=VALUE     evaluate some Lua code before processing file
+  -o, --output=[FILE]      explicitly set output file name
   -I, --include=[FILE]     include a class or SILE file before processing input
       --help               display this help, then exit
       --version            display version information, then exit
@@ -94,6 +95,9 @@ Options:
   if opts.evaluate then
     SILE.dolua,err = loadstring(opts.evaluate)
     if err then SU.error(err) end
+  end
+  if opts.output then
+    SILE.outputFilename = opts.output
   end
   if opts.include then
     SILE.preamble = opts.include

--- a/documentation/sile.sil
+++ b/documentation/sile.sil
@@ -935,9 +935,10 @@ do anything that it’s possible to do in Lua.
 
 As mentioned above, loading a package is done through the \code{\\script} command,
 which runs Lua code. By convention packages live in the \code{packages/} subdirectory
-of either your working directory or SILE’s installation directory. For instance,
-we’ll soon be talking about the \code{grid} package, which normally can be found
-as \code{/usr/local/lib/sile/packages/grid.lua}. To load this, we’d say:
+of either your input file's location, your current working directory or SILE’s
+installation directory. For instance, we’ll soon be talking about the
+\code{grid} package, which normally can be found as
+\code{/usr/local/lib/sile/packages/grid.lua}. To load this, we’d say:
 
 \begin{verbatim}
 \line
@@ -945,10 +946,12 @@ as \code{/usr/local/lib/sile/packages/grid.lua}. To load this, we’d say:
 \line
 \end{verbatim}
 
-\note{\notehead{How SILE locates files} SILE searches for paths in a variety of directories: first, in the current directory;
-next, if the environment variable \code{SILE_PATH} is set, it will look in that
-directory; then it will look in the standard installation directories \code{/usr/lib/sile}
-and \code{/usr/local/lib/sile}. Unlike TeX, it does not descend into subdirectories
+\note{\notehead{How SILE locates files} SILE searches for paths in a variety of
+directories: first, in the directory in which your input file is located,
+then the current wording directory; next, if the environment variable
+\code{SILE_PATH} is set, it will look in that directory; then it will look in
+the standard installation directories \code{/usr/lib/sile} and
+\code{/usr/local/lib/sile}. Unlike TeX, it does not descend into subdirectories
 when looking for a file, and so if you have arranged your personal macro, class
 or package files into subdirectories, you will need to provide a full relative
 path to them.}
@@ -1924,11 +1927,12 @@ Now we know how to define a frame layout for a single page, let’s try
 to define one for an entire document.
 
 Document classes are Lua files, and live somewhere in the \code{classes/}
-subdirectory of either your current directory or your SILE path (typically
-\code{/usr/local/share/sile}). We’re going to create a simple class file
-which merely changes the size of the margins and the typeblock. We’ll call
-it \code{bringhurst.lua}, because it replicates the layout of the Hartley
-& Marks edition of Robert Bringhurst’s \em{The Elements of Typographical Style}.
+subdirectory of either where your input file is located, your current working
+directory or your SILE path (typically \code{/usr/local/share/sile}). We’re
+going to create a simple class file which merely changes the size of the
+margins and the typeblock. We’ll call it \code{bringhurst.lua}, because it
+replicates the layout of the Hartley & Marks edition of Robert Bringhurst’s
+\em{The Elements of Typographical Style}.
 
 We are designing a book-like class, and so we will inherit from SILE’s
 standard \code{book} class, \code{classes/book.lua}.

--- a/documentation/sile.sil
+++ b/documentation/sile.sil
@@ -2230,7 +2230,7 @@ routine.
 \line
 local writeToc = function (self)
   local t = std.string.pickle(SILE.scratch.tableofcontents)
-  saveFile(t, SILE.masterFileName .. '.toc')
+  saveFile(t, SILE.masterFilename .. '.toc')
 end
 \line
 \end{verbatim}
@@ -2241,7 +2241,7 @@ present, and typesets the TOC nodes appropriately:
 \begin{verbatim}
 \line
 SILE.registerCommand("tableofcontents", function (options, content)
-  local toc = loadFile(SILE.masterFileName .. '.toc')
+  local toc = loadFile(SILE.masterFilename .. '.toc')
   if not toc then
     SILE.call("tableofcontents:notocmessage")
     return

--- a/packages/tableofcontents.lua
+++ b/packages/tableofcontents.lua
@@ -20,13 +20,13 @@ end
 
 local writeToc = function ()
   local t = "return "..std.string.pickle(SILE.scratch.tableofcontents)
-  local f,err = io.open(SILE.masterFileName .. '.toc',"w")
+  local f,err = io.open(SILE.masterFilename .. '.toc',"w")
   if not f then return SU.error(err) end
   f:write(t)
 end
 
 SILE.registerCommand("tableofcontents", function (options, content)
-  local f,err = io.open(SILE.masterFileName .. '.toc')
+  local f,err = io.open(SILE.masterFilename .. '.toc')
   if not f then
     SILE.call("tableofcontents:notocmessage")
     return

--- a/sile.in
+++ b/sile.in
@@ -6,7 +6,7 @@ SILE = require("core/sile")
 io.stdout:setvbuf 'no'
 SILE.parseArguments()
 if not os.getenv 'LUA_REPL_RLWRAP' then
-  print('This is SILE '..SILE.version)
+  io.stderr:write('This is SILE '..SILE.version..'\n')
 end
 SILE.init()
 if unparsed and unparsed[1] then

--- a/sile.in
+++ b/sile.in
@@ -10,7 +10,8 @@ if not os.getenv 'LUA_REPL_RLWRAP' then
 end
 SILE.init()
 if unparsed and unparsed[1] then
-  SILE.masterFilename = unparsed[1]
+  -- Turn slashes around in the event we get passed a path from a Windows shell
+  SILE.masterFilename = unparsed[1]:gsub("\\", "/")
   if SILE.preamble then
     print("Loading "..SILE.preamble)
     local c = SILE.resolveFile("classes/"..SILE.preamble)

--- a/sile.in
+++ b/sile.in
@@ -10,7 +10,7 @@ if not os.getenv 'LUA_REPL_RLWRAP' then
 end
 SILE.init()
 if unparsed and unparsed[1] then
-  SILE.masterFileName = unparsed[1]
+  SILE.masterFilename = unparsed[1]
   if SILE.preamble then
     print("Loading "..SILE.preamble)
     local c = SILE.resolveFile("classes/"..SILE.preamble)

--- a/tests/alignment.expected
+++ b/tests/alignment.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/alignment.sil>Open file	tests/alignment.pdf
 Set paper size 	595.275597	841.8897729
 Begin page

--- a/tests/arabic-scripts.expected
+++ b/tests/arabic-scripts.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/arabic-scripts.sil>Open file	tests/arabic-scripts.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/balanced.expected
+++ b/tests/balanced.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/balanced.sil>Open file	tests/balanced.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/bug-124_upstream.expected
+++ b/tests/bug-124_upstream.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/bug-124.sil>Open file	tests/bug-124.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/bug-132.expected
+++ b/tests/bug-132.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/bug-132.sil>Open file	tests/bug-132.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/bug-39.expected
+++ b/tests/bug-39.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/bug-39.sil>Open file	tests/bug-39.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/bug-54.expected
+++ b/tests/bug-54.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/bug-54.sil>Open file	tests/bug-54.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/bug-61.expected
+++ b/tests/bug-61.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/bug-61.sil>Open file	tests/bug-61.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/bug-62.expected
+++ b/tests/bug-62.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/bug-62.sil>Open file	tests/bug-62.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/bug-75_darwin.expected
+++ b/tests/bug-75_darwin.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/bug-75_darwin.sil>Open file	tests/bug-75_darwin.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/bug-76.expected
+++ b/tests/bug-76.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/bug-76.sil>Open file	tests/bug-76.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/bug-79.expected
+++ b/tests/bug-79.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/bug-79.sil>Open file	tests/bug-79.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/bug-80.expected
+++ b/tests/bug-80.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/bug-80.sil>Open file	tests/bug-80.pdf
 Set paper size 	595.275597	841.8897729
 Begin page

--- a/tests/centering.expected
+++ b/tests/centering.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/centering.sil>Open file	tests/centering.pdf
 Set paper size 	595.275597	841.8897729
 Begin page

--- a/tests/combining.expected
+++ b/tests/combining.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/combining.sil>Open file	tests/combining.pdf
 Set paper size 	595.275597	841.8897729
 Begin page

--- a/tests/crash.expected
+++ b/tests/crash.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/crash.sil>Open file	tests/crash.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/disappearing-skip.expected
+++ b/tests/disappearing-skip.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/disappearing-skip.sil>Open file	tests/disappearing-skip.pdf
 Set paper size 	365.6692953	561.2598486
 Begin page

--- a/tests/eject.expected
+++ b/tests/eject.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/eject.sil>Open file	tests/eject.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/grid.expected
+++ b/tests/grid.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/grid.sil>Open file	tests/grid.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/image.expected
+++ b/tests/image.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/image.sil>Open file	tests/image.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/kannada.expected
+++ b/tests/kannada.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/kannada.sil>Open file	tests/kannada.pdf
 Set paper size 	595.275597	841.8897729
 Begin page

--- a/tests/mini-arabic.expected
+++ b/tests/mini-arabic.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/mini-arabic.sil>Open file	tests/mini-arabic.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/mlcounter.expected
+++ b/tests/mlcounter.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/mlcounter.sil>Open file	tests/mlcounter.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/nondeterminism.expected
+++ b/tests/nondeterminism.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/nondeterminism.sil>Open file	tests/nondeterminism.pdf
 Set paper size 	595.275597	841.8897729
 Begin page

--- a/tests/rskip.expected
+++ b/tests/rskip.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/rskip.sil>Open file	tests/rskip.pdf
 Set paper size 	419.5275636	595.275597
 Begin page

--- a/tests/split-footnote.expected
+++ b/tests/split-footnote.expected
@@ -1,4 +1,3 @@
-This is SILE 0.9.3-unreleased
 <tests/split-footnote.sil>Open file	tests/split-footnote.pdf
 Set paper size 	419.5275636	595.275597
 Begin page


### PR DESCRIPTION
This should fix #91 by first searching for includes and requires from the directory of the input file before moving on down the path chain. Additionally a few other odds and ends I ran into are touched up as well. See commit messages for details.