### PR TITLE
fix bootstrap.sh script failing on sed

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,4 +11,5 @@ fi
 
 autoreconf --install
 (cd libtexpdf; autoreconf -I m4)
-sed 's/rm -f core/rm -f/' -i configure
+sed -e 's/rm -f core/rm -f/' -i.bak configure
+rm -f configure.bak


### PR DESCRIPTION
the bootstrap.sh script return non-zero exit code, making it impossible to install sile from `--HEAD` using brew.

```
sed: -i: No such file or directory
```

Unlike GNU sed, on OSX the sed command requires that the `-i` (inplace) option be followed by an argument for the extension for the backup file.