### PR TITLE
fix bootstrap.sh script failing on sed

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,4 +11,4 @@ fi
 
 autoreconf --install
 (cd libtexpdf; autoreconf -I m4)
-sed 's/rm -f core/rm -f/' -i configure
+sed -i -e 's/rm -f core/rm -f/' configure


### PR DESCRIPTION
the bootstrap.sh script return non-zero exit code, making it impossible
to install sile from --HEAD using brew.

```
sed: -i: No such file or directory
```

Thanks @alerque for suggesting a better fix!