### PR TITLE
Write error messages to STDERR channel

### DIFF
--- a/sile.in
+++ b/sile.in
@@ -29,7 +29,7 @@ if unparsed and unparsed[1] then
     if e:match(": interrupted!") then
       SILE.outputter:finish()
     else
-      io.write("\nError detected:\n"..e.."\n")
+      io.stderr:write("\nError detected:\n"..e.."\n")
     end
     os.exit(1)
   end


### PR DESCRIPTION
See discussion in #147

This should pass through errors to the terminal rather than being caught
by IO redirects. Notably running the regression tests will show errors
on the console rather than them ending up in the test output file.