### PR TITLE
Expand test case for whitespace-around-commands

### DIFF
--- a/tests/space-after-command.expected
+++ b/tests/space-after-command.expected
@@ -1,61 +1,198 @@
 <tests/space-after-command.sil>Open file	tests/space-after-command.pdf
 Set paper size 	419.5275636	595.275597
 Begin page
-Mx 	40.97638
+Mx 	20.97638
 My 	37.33214
 Set font 	Gentium;10;200;normal;normal;;LTR
-T	52 69 83 84	(Test)
-Mx 	61.07209
-T	84 65 73 76 73 78 71	(tailing)
-Mx 	90.29378
-T	67 79 77 77 65 78 68	(command)
-Mx 	133.72933
-Set font 	Gentium;10;200;italic;normal;;LTR
-T	73 78 83 73 68 69	(inside)
-Mx 	158.39047
-Set font 	Gentium;10;200;normal;normal;;LTR
-T	80 65 82 65 71 82 65 80 72 14	(paragraph.)
-Mx 	40.97638
-My 	52.33214
-Set font 	Gentium;10;200;italic;normal;;LTR
-T	52 69 83 84	(Test)
-Mx 	59.08009
-T	76 69 65 68 73 78 71	(leading)
-Mx 	89.10550
-Set font 	Gentium;10;200;normal;normal;;LTR
-T	67 79 77 77 65 78 68	(command)
-Mx 	132.53912
-T	65 84	(at)
-Mx 	143.23348
-T	83 84 65 82 84	(start)
-Mx 	165.19249
-T	79 70	(of)
-Mx 	175.99427
-T	80 65 82 65 71 82 65 80 72 14	(paragraph.)
-Mx 	40.97638
-My 	67.33214
-T	52 69 83 84	(Test)
-Mx 	61.07364
-T	67 79 77 77 65 78 68	(command)
-Mx 	104.51074
-T	65 78 68	(and)
-Mx 	122.48397
-Set font 	Gentium;10;200;italic;normal;;LTR
-T	69 78 68	(end)
-Mx 	138.51078
-T	79 70	(of)
-Mx 	147.88231
-T	80 65 82 65 71 82 65 80 72 14	(paragraph.)
-Mx 	40.97638
-My 	82.33214
-Set font 	Gentium;10;200;normal;normal;;LTR
-T	51 72 79 85 76 68	(Should)
-Mx 	72.16202
+T	46 79 84 69 26	(Note:)
+Mx 	46.26395
+T	69 65 67 72	(each)
+Mx 	68.63160
+T	83 69 78 84 69 78 67 69	(sentence)
+Mx 	108.61644
+T	66 69 76 79 87	(below)
+Mx 	136.38448
+T	83 72 79 85 76 68	(should)
+Mx 	167.41913
 T	66 69	(be)
-Mx 	84.52930
-T	78 69 87	(new)
-Mx 	104.39658
+Mx 	180.53385
+T	73 78	(in)
+Mx 	192.17885
+T	73 84 83	(its)
+Mx 	205.61095
+T	79 87 78	(own)
+Mx 	226.48934
+T	80 65 82 65 71 82 65 80 72	(paragraph)
+Mx 	272.39215
+T	87 73 84 72	(with)
+Mx 	294.54008
+T	78 79	(no)
+Mx 	308.50441
+T	76 73 78 69	(line)
+Mx 	327.47850
+T	66 82 69 65 75 83	(breaks)
+Mx 	357.85885
+T	79 82	(or)
+Mx 	370.26557
+T	87 79 82 68 83	(words)
+Mx 	20.97638
+My 	51.33214
+T	83 76 65 77 77 69 68	(slammed)
+Mx 	60.67379
+T	84 79 71 69 84 72 69 82 14	(together.)
+Mx 	100.39074
+T	33 76 76	(All)
+Mx 	114.41433
+T	80 65 82 65 71 82 65 80 72 83	(paragraphs)
+Mx 	163.41350
+T	8 69 88 67 69 80 84	((except)
+Mx 	196.46541
+T	84 72 73 83	(this)
+Mx 	214.64915
+T	79 78 69 9	(one))
+Mx 	235.63563
+T	83 72 79 85 76 68	(should)
+Mx 	265.90433
+T	66 69	(be)
+Mx 	278.25312
+T	73 78 68 69 78 84 69 68 14	(indented.)
+Mx 	40.97638
+My 	66.33214
+T	52 69 83 84	(Test)
+Mx 	60.67109
+T	67 79 77 77 65 78 68	(command)
+Mx 	104.09626
+T	84 82 65 73 76 73 78 71	(trailing)
+Mx 	137.16987
+T	65 84	(at)
+Mx 	147.85579
+T	84 72 69	(the)
+Mx 	164.08859
+T	69 78 68	(end)
+Mx 	182.07919
+T	79 70	(of)
+Mx 	192.87253
+T	65	(a)
+Mx 	200.11607
+T	76 73 78 69	(line)
+Push color	0.0	0.0	1.0
+Mx 	218.32640
+T	73 78 83 73 68 69	(inside)
+Pop color
+Mx 	245.59923
+T	65	(a)
+Mx 	252.84277
 T	80 65 82 65 71 82 65 80 72 14	(paragraph.)
+Mx 	40.97638
+Push color	0.0	0.0	1.0
+Pop color
+My 	81.33214
+T	52 69 83 84	(Test)
+Mx 	60.67590
+T	67 79 77 77 65 78 68	(command)
+Mx 	104.10589
+Pop color
+T	76 69 65 68 68 73 78 71	(leadding)
+Mx 	142.18920
+T	65 84	(at)
+Mx 	152.87993
+T	84 72 69	(the)
+Mx 	169.11754
+T	83 84 65 82 84	(start)
+Mx 	191.07292
+T	79 70	(of)
+Mx 	201.87108
+T	65	(a)
+Mx 	209.11943
+T	80 65 82 65 71 82 65 80 72 14	(paragraph.)
+Mx 	40.97638
+My 	96.33214
+T	52 69 83 84	(Test)
+Mx 	60.68053
+T	67 79 77 77 65 78 68	(command)
+Mx 	104.11514
+T	65 84	(at)
+Mx 	114.81050
+T	84 72 69	(the)
+Push color	0.0	0.0	1.0
+Mx 	131.05273
+T	69 78 68	(end)
+Mx 	149.05278
+T	79 70	(of)
+Mx 	159.85556
+T	65	(a)
+Mx 	167.10853
+T	80 65 82 65 71 82 65 80 72 14	(paragraph.)
+Pop color
+Mx 	40.97638
+My 	111.33214
+Set font 	Gentium;10;200;italic;normal;;LTR
+T	52 69 83 84	(Test)
+Mx 	58.73345
+T	67 79 77 77 65 78 68	(command)
+Mx 	97.85770
+T	79 86 69 82	(over)
+Mx 	116.16653
+T	70 85 76 76	(full)
+Mx 	131.00856
+T	80 65 82 65 71 82 65 80 72 14	(paragraph.)
+Mx 	40.97638
+My 	126.33214
+Set font 	Gentium;10;200;normal;normal;;LTR
+T	52 69 83 84	(Test)
+Mx 	60.67817
+T	66 65 67 75	(back)
+Mx 	82.23055
+T	84 79	(to)
+Mx 	93.36301
+T	66 65 67 75	(back)
+Mx 	114.91538
+T	67 79 77 77 65 78 68 83	(commands)
+Mx 	162.20995
+T	79 78	(on)
+Mx 	175.41760
+T	84 72 69	(the)
+Push color	0.0	0.0	1.0
+Mx 	191.65748
+T	83 65 77 69	(same)
+Pop color
+Push color	0.0	0.50196078431373	0.0
+Mx 	215.42177
+T	76 73 78 69	(line)
+Pop color
+Mx 	230.97841
+T	14	(.)
+Mx 	40.97638
+My 	141.33214
+T	52 69 83 84	(Test)
+Mx 	60.66846
+T	67 79 77 77 65 78 68	(command)
+Push color	0.0	0.0	1.0
+Mx 	104.09100
+T	65 84	(at)
+Mx 	114.77429
+T	84 72 69	(the)
+Mx 	131.00445
+T	69 78 68	(end)
+Mx 	148.99243
+T	79 78	(on)
+Mx 	162.19036
+T	79 78 69	(one)
+Mx 	180.00744
+T	76 73 78 69	(line)
+Pop color
+Push color	0.0	0.50196078431373	0.0
+Mx 	198.21514
+T	65 78 68	(and)
+Mx 	216.17382
+T	84 72 69	(the)
+Mx 	232.40399
+T	66 69 71 73 78 78 73 78 71	(beginning)
+Pop color
+Mx 	276.48083
+T	79 70	(of)
+Mx 	287.27154
+T	65 78 79 84 72 69 82 14	(another.)
 [1] Mx 	207.41759
 My 	553.73265
 T	17	(1)

--- a/tests/space-after-command.sil
+++ b/tests/space-after-command.sil
@@ -2,13 +2,21 @@
 % Test leading comment and package lines
 \script[src=packages/color]
 
-Test tailing command \em{inside}
-paragraph.
+\noindent Note: each sentence below should be in its own paragraph with no
+line breaks or words slammed together. All paragraphs (except this one) should
+be indented.
 
-\em{Test leading} command at start of paragraph.
+Test command trailing at the end of a line \color[color=blue]{inside}
+a paragraph.
 
+\color[color=blue]{Test command} leadding at the start of a paragraph.
 
-Test command and \em{end of paragraph.}
+Test command at the \color[color=blue]{end of a paragraph.}
 
-Should be new paragraph.
+\em{Test command over full paragraph.}
+
+Test back to back commands on the \color[color=blue]{same} \color[color=green]{line}.
+
+Test command \color[color=blue]{at the end on one line}
+\color[color=green]{and the beginning} of another.
 \end{document}


### PR DESCRIPTION
See issue #105

Add two new test cases:

 1. The case of \em vs. \font is currently handled differently and one
    eats indentation at the start of a paragraph and the other doesn't.

 2. A command trailing a line and another leading a new line does not
    insert a space between sequential words as expected.

Additionally I documented what is expected of the test a little better
for ease of manual review.