### PR TITLE
Run Travis tests with and without ICU

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ env:
    - LUAROCKS_BASE=luarocks-2.2.2
    - HARFBUZZ_BASE=harfbuzz-1.0.1
    - GRAPHITE=true
+   - ICU=true
   matrix:
    - LUA_VER=5.3 LUA_52_COMPAT=true LUA_53_BASE=lua-5.3.1
    - LUA_VER=5.3 LUA_52_COMPAT=false LUA_53_BASE=lua-5.3.1
    - LUA_VER=5.2
    - LUA_VER=5.2 GRAPHITE=false
+   - LUA_VER=5.2 ICU=false
    - LUA_VER=5.1
 before_install:
  - export LUA_PKG=lua$LUA_VER LUA_DEV=liblua$LUA_VER-dev LUA_SFX=$LUA_VER
@@ -21,7 +23,8 @@ before_install:
    }
    # Note installing graphite must be done before adding the SIL PPA because
    # their packages of the same name have broken dependencies
- - if $GRAPHITE; then sudo apt-get install libgraphite2-dev; fi
+ - if $GRAPHITE; then sudo apt-get install -y libgraphite2-dev; fi
+ - if $ICU; then sudo apt-get install -y libicu-dev; fi
    # Add SIL's PPA repository because it has newer versions of fonts
  - curl http://packages.sil.org/sil.gpg | sudo apt-key add -
  - echo 'deb http://packages.sil.org/ubuntu precise main' | sudo tee -a /etc/apt/sources.list
@@ -43,6 +46,7 @@ before_install:
    fi
    # Install devel libraries and headers (for compiling libtexpdf)
  - sudo apt-get install -y lib{freetype6,fontconfig1,png,expat1}-dev
+ - if $ICU; then sudo apt-get install -y libicu-dev; fi
    # Install fonts (needed for typesetting regression tests)
  - sudo apt-get install -y fonts-sil-{scheherazade,lateef,gentium{,-basic}}
  - get_noto NaskhArabic && get_noto SansKannada


### PR DESCRIPTION
Default to with for most of the runs but do one run on Lua 5.2 without.

See issue #159.