### PR TITLE
Use only POSIX shell syntax for portability

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@
 # and we are part of a git repository that the user has not fully initialized,
 # go ahead and do the step of fetching the the submodule so the compile process
 # can run.
-if [[ ! -f libtexpdf/configure.ac && -d .git ]]; then
+if [ ! -f "libtexpdf/configure.ac" ] && [ -d ".git" ]; then
     git submodule update --init --recursive --remote
 fi
 


### PR DESCRIPTION
Fixes issue #168

We either need to use bash as the interpreter here (which would probably
be fine) or actually limit ourselves to POSIX compliant syntax.  The
double bracket test is superior in a number of ways but not available
in the POSIX subset.