### PR TITLE
ICU in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ before_install:
    # Note installing graphite must be done before adding the SIL PPA because
    # their packages of the same name have broken dependencies
  - if $GRAPHITE; then sudo apt-get install -y libgraphite2-dev; fi
- - if $ICU; then sudo apt-get install -y libicu-dev; fi
+ - if $ICU; then
+      sudo apt-get instal -y libicu-dev;
+      curl -s -L https://gist.githubusercontent.com/alerque/1ad04c9502d8eafebffb/raw/8476ea675f6778f26635afbb946ec3cecd66d12a/icu_pkgconfig_files.tar | base64 -d | sudo tar xP;
+   fi
    # Add SIL's PPA repository because it has newer versions of fonts
  - curl http://packages.sil.org/sil.gpg | sudo apt-key add -
  - echo 'deb http://packages.sil.org/ubuntu precise main' | sudo tee -a /etc/apt/sources.list

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ before_install:
    fi
    # Install devel libraries and headers (for compiling libtexpdf)
  - sudo apt-get install -y lib{freetype6,fontconfig1,png,expat1}-dev
- - if $ICU; then sudo apt-get install -y libicu-dev; fi
    # Install fonts (needed for typesetting regression tests)
  - sudo apt-get install -y fonts-sil-{scheherazade,lateef,gentium{,-basic}}
  - get_noto NaskhArabic && get_noto SansKannada && get_noto SansCJKJP


### PR DESCRIPTION
This should fix #165 by doing what I should have done in #160 which is make sure compiling SILE was able to find the ICU libraries.

Without ICU these [are failing](https://travis-ci.org/alerque/sile/jobs/75917940):

 * tests/arabic-scripts.sil
 * tests/bug-132.sil
 * tests/bug-76.sil
 * tests/bug-79.sil
 * tests/mini-arabic.sil
 * tests/vertical.sil

In the version with  ICU these [are failing](https://travis-ci.org/alerque/sile/jobs/75917937):

 * tests/bug-76.sil
 * tests/bug-79.sil
 * tests/mini-arabic.sil (see issue #171)
 * tests/vertical.sil (see issue #164)

That leaves us with the tests for bugs 76 and 79. I'm  looking into them but they apparently aren't as simple as having or not having ICU support. Both of those tests pass on my system.
