### PR TITLE
\nofolios should’t suppress showing progress

### DIFF
--- a/packages/folio.lua
+++ b/packages/folio.lua
@@ -15,6 +15,7 @@ return {
         if SILE.scratch.counters.folio.off == 2 then
           SILE.scratch.counters.folio.off = false
         end
+        io.write("["..SILE.formatCounter(SILE.scratch.counters.folio).."] ");
         SILE.scratch.counters.folio.value = SILE.scratch.counters.folio.value + 1
         return
       end

--- a/packages/folio.lua
+++ b/packages/folio.lua
@@ -11,26 +11,24 @@ return {
   exports = {
     outputFolio = function (this, frame)
       if not frame then frame = "folio" end
+      io.write("["..SILE.formatCounter(SILE.scratch.counters.folio).."] ");
       if SILE.scratch.counters.folio.off then
         if SILE.scratch.counters.folio.off == 2 then
           SILE.scratch.counters.folio.off = false
         end
-        io.write("["..SILE.formatCounter(SILE.scratch.counters.folio).."] ");
-        SILE.scratch.counters.folio.value = SILE.scratch.counters.folio.value + 1
-        return
-      end
-      io.write("["..SILE.formatCounter(SILE.scratch.counters.folio).."] ");
-      local f = SILE.getFrame("folio");
-      if (f) then
-        SILE.typesetNaturally(f, function()
-          SILE.settings.pushState()
-          SILE.settings.reset()
-          SILE.call("center", {}, function()
-            SILE.typesetter:typeset(SILE.formatCounter(SILE.scratch.counters.folio))
+      else
+        local f = SILE.getFrame("folio");
+        if (f) then
+          SILE.typesetNaturally(f, function()
+            SILE.settings.pushState()
+            SILE.settings.reset()
+            SILE.call("center", {}, function()
+              SILE.typesetter:typeset(SILE.formatCounter(SILE.scratch.counters.folio))
+            end)
+            SILE.typesetter:leaveHmode()
+            SILE.settings.popState()
           end)
-          SILE.typesetter:leaveHmode()
-          SILE.settings.popState()
-        end)
+        end
       end
       SILE.scratch.counters.folio.value = SILE.scratch.counters.folio.value + 1
     end

--- a/tests/balanced.expected
+++ b/tests/balanced.expected
@@ -1198,6 +1198,6 @@ My 	525.36083
 T	73 66 69	(had)
 Mx 	234.08448
 T	69 80 79 70 15	(done.)
-End page
+[1] End page
 Finish
 

--- a/tests/masters.expected
+++ b/tests/masters.expected
@@ -214,7 +214,7 @@ Mx 	196.25400
 T	83 73 84	(sit)
 Mx 	208.91774
 T	65 77 69 84	(amet)
-New page
+[1] New page
 Mx 	49.76378
 My 	57.23121
 Set font 	Gentium;20;200;normal;normal;;LTR
@@ -450,7 +450,7 @@ Mx 	436.15290
 T	83 73 84	(sit)
 Mx 	448.82070
 T	65 77 69 84	(amet)
-New page
+[2] New page
 Mx 	49.76378
 My 	40.39341
 Set font 	Gentium;20;200;normal;normal;;LTR
@@ -676,7 +676,7 @@ Mx 	196.25400
 T	83 73 84	(sit)
 Mx 	208.91774
 T	65 77 69 84	(amet)
-New page
-End page
+[3] New page
+[4] End page
 Finish
 


### PR DESCRIPTION
When set no page numbers are printed on the console, which doesn’t seem to a be an intended side effect.