### PR TITLE
Bump Harfbuzz version in Travis config to 1.0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
 env:
   global:
    - LUAROCKS_BASE=luarocks-2.2.2
-   - HARFBUZZ_BASE=harfbuzz-1.0.4
+   - HARFBUZZ_BASE=harfbuzz-1.0.6
    - GRAPHITE=true
    - ICU=true
   matrix:


### PR DESCRIPTION
If desired merge this after a fix for #186 is in place to avoid Travis flashing red at us.

Also if you like I can split the build up to test across multiple versions of Harfbuzz if the fix for this could involve future breakage but I've left it at one for now pending better knowledge of what we are testing for and why.