### PR TITLE
Fix regression due to 820e8d9

### DIFF
--- a/core/sile.lua
+++ b/core/sile.lua
@@ -88,6 +88,8 @@ Options:
 
   parser:on ('--', parser.finished)
   _G.unparsed, _G.opts = parser:parse(_G.arg)
+  -- Turn slashes around in the event we get passed a path from a Windows shell
+  SILE.masterFilename = _G.unparsed[1]:gsub("\\", "/")
   SILE.debugFlags = {}
   if opts.backend then
     SILE.backend = opts.backend
@@ -180,6 +182,7 @@ end
 function SILE.resolveFile(fn)
   if file_exists(fn) then return fn end
   if file_exists(fn..".sil") then return fn..".sil" end
+  if not SILE.masterFilename then return nil end
 
   local dirname = SILE.masterFilename:match("(.-)[^%/]+$")
   for k in SU.gtoke(dirname..";"..tostring(os.getenv("SILE_PATH")), ";") do

--- a/sile.in
+++ b/sile.in
@@ -9,9 +9,7 @@ if not os.getenv 'LUA_REPL_RLWRAP' then
   io.stderr:write('This is SILE '..SILE.version..'\n')
 end
 SILE.init()
-if unparsed and unparsed[1] then
-  -- Turn slashes around in the event we get passed a path from a Windows shell
-  SILE.masterFilename = unparsed[1]:gsub("\\", "/")
+if SILE.masterFilename then
   if SILE.preamble then
     print("Loading "..SILE.preamble)
     local c = SILE.resolveFile("classes/"..SILE.preamble)


### PR DESCRIPTION
@deepakjois already mentioned this in #184, but this in some scenarios masterFilename is getting called before initialization. This is the same fix from Deepak's original commit (5b346a6) with the comment that goes with the code line moved to match.

I didn't look very hand to see if there is a better way to fix this, but it does need to get fixed.