### PR TITLE
Unravel interdependency between packages

### DIFF
--- a/classes/markdown.lua
+++ b/classes/markdown.lua
@@ -20,7 +20,8 @@ SILE.inputs.markdown = {
   end
 }
 
-SILE.require("packages/verbatim")
+SILE.require("packages/url")
+
 local book = SILE.require("classes/book")
 
 SILE.registerCommand("sect1", function(options, content)
@@ -48,20 +49,11 @@ SILE.registerCommand("bulletlist", function(options, content)
   SILE.process(content)
 end)
 
-SILE.registerCommand("code", function(options, content)
-  SILE.settings.temporarily(function()
-    SILE.call("verbatim:font")
-    SILE.process(content)
-    SILE.typesetter:typeset(" ")
-  end)
-end)
-
 SILE.registerCommand("link", function(options, content)
   -- SILE.settings.temporarily(function()
     -- SILE.call("verbatim:font")
     SILE.process(content)
   -- end)
 end)
-
 
 return book

--- a/packages/url.lua
+++ b/packages/url.lua
@@ -17,8 +17,18 @@ local filter = function (v, content, data)
   return result
 end
 
+SILE.require("packages/verbatim")
+
 SILE.registerCommand("url", function (options,content)
   local breakpat = options.breakpat or "/"
   local result = inputfilter.transformContent(content, filter, breakpat)
   SILE.call("code", {}, result)
+end)
+
+SILE.registerCommand("code", function(options, content)
+  SILE.settings.temporarily(function()
+    SILE.call("verbatim:font")
+    SILE.process(content)
+    SILE.typesetter:typeset(" ")
+  end)
 end)


### PR DESCRIPTION
The `url` package was providing `\url`, which in turn was calling
`\code`, but that wasn't defined (unless your document happened to do
so). The `markdown` package meanwhile did have a working definition for
`\code`. Re-arranging this means that loading any one of the packages
will actually get them each the commands they need to run.