### PR TITLE
Improve localization

### DIFF
--- a/classes/book.lua
+++ b/classes/book.lua
@@ -87,7 +87,7 @@ end)
 book.registerCommands = function()
   plain.registerCommands()
 SILE.doTexlike([[%
-\define[command=book:chapter:pre]{Chapter }%
+\define[command=book:chapter:pre]{}%
 \define[command=book:chapter:post]{\par}%
 \define[command=book:section:post]{ }%
 \define[command=book:subsection:post]{ }%

--- a/languages/en.lua
+++ b/languages/en.lua
@@ -597,3 +597,9 @@ SILE.hyphenator.languages["en"].exceptions = {"as-so-ciate", "as-so-ciates",
 "dec-li-na-tion", "oblig-a-tory", "phil-an-thropic", "present",
 "presents", "project", "projects", "reci-procity", "re-cog-ni-zance",
 "ref-or-ma-tion", "ret-ri-bu-tion", "ta-ble"};
+
+-- Internationalisation stuff
+SILE.doTexlike([[%
+\define[command=tableofcontents:title]{Table of Contents}%
+\define[command=book:chapter:pre:en]{Chapter }%
+]])

--- a/languages/tr.lua
+++ b/languages/tr.lua
@@ -607,3 +607,9 @@ SILE.hyphenator.languages["tr"].patterns =
 "tu4r4k",
 "m1t4rak",
    };
+
+-- Internationalisation stuff
+SILE.doTexlike([[%
+\define[command=tableofcontents:title]{İçindekiler}%
+\define[command=book:chapter:pre:tr]{Bölüm }%
+]])

--- a/packages/tableofcontents.lua
+++ b/packages/tableofcontents.lua
@@ -68,9 +68,10 @@ return {
   init = function (self)
     self:loadPackage("infonode")
 SILE.doTexlike([[%
+\define[command=tableofcontents:title]{}%
 \define[command=tableofcontents:notocmessage]{\tableofcontents:headerfont{Rerun SILE to process table of contents!}}%
 \define[command=tableofcontents:headerfont]{\font[size=24pt,weight=800]{\process}}%
-\define[command=tableofcontents:header]{\par\noindent\tableofcontents:headerfont{Table of Contents}\medskip}%
+\define[command=tableofcontents:header]{\par\noindent\tableofcontents:headerfont{\tableofcontents:title}\medskip}%
 \define[command=tableofcontents:level1item]{\bigskip\noindent\font[size=14pt,weight=800]{\process}\medskip}%
 \define[command=tableofcontents:level2item]{\noindent\font[size=12pt]{\process}\medskip}%
 \define[command=tableofcontents:level3item]{\indent\font[size=10pt]{\process}\smallskip}%


### PR DESCRIPTION
This moves English only output into the EN localization, adds a function for localizing TOC headers and adds localized strings for Turkish. Blank default strings rather than English seems like a better way to encourage properly setting the document language and adding localizations to all languages.