### PR TITLE
Suppress 2× repetitions of leader when there is only space for 1×

### DIFF
--- a/packages/leaders.lua
+++ b/packages/leaders.lua
@@ -20,12 +20,14 @@ leader.outputYourself = function (self,typesetter, line)
     typesetter.frame:advanceWritingDirection(remainder/2)
   end
 
-  local glue = remainder / (repetitions-1)
-  for i=1,(repetitions-1) do
+  if repetitions > 1 then
+    local glue = remainder / (repetitions-1)
+    for i=1,(repetitions-1) do
+      self.value:outputYourself(typesetter, line)
+      typesetter.frame:advanceWritingDirection(glue)
+    end
     self.value:outputYourself(typesetter, line)
-    typesetter.frame:advanceWritingDirection(glue)
   end
-  self.value:outputYourself(typesetter, line)
 end
 
 SILE.registerCommand("leaders", function(o,c)


### PR DESCRIPTION
The previous code would output a minimum of two repetitions of the
leader even after calculating that there was only space for one. This
would push the page number out of bounds in TOC entries that filled up
most of the space. The calculation for 0× repetitions worked and
anything over 2× worked, but if there was really only space for 1×
filler it was getting output twice anyway.