### PR TITLE
Add push/pop state back to footnote typesetter

### DIFF
--- a/packages/footnotes.lua
+++ b/packages/footnotes.lua
@@ -40,6 +40,7 @@ SILE.registerCommand("footnote", function(options, content)
   SILE.typesetter = SILE.typesetter {}
   SILE.typesetter:init(f)
   SILE.typesetter.pageTarget = function () return 0xFFFFFF end
+  SILE.settings.pushState()
   SILE.settings.reset()
   local material = SILE.Commands["vbox"]({}, function()
     SILE.Commands["font"]({size = "9pt"}, function()
@@ -47,8 +48,8 @@ SILE.registerCommand("footnote", function(options, content)
       SILE.call("footnote:counter")
       SILE.process(content)
     end)
-  end
-  )
+  end)
+  SILE.settings.popState()
   SILE.typesetter = oldT
   insertions.exports:insert("footnote", material)
   SILE.scratch.counters.footnote.value = SILE.scratch.counters.footnote.value + 1


### PR DESCRIPTION
Fixes issue #231

See commit b3072fa for where this issue was introduced.