### PR TITLE
Make footnote font configurable

### DIFF
--- a/packages/footnotes.lua
+++ b/packages/footnotes.lua
@@ -42,7 +42,7 @@ SILE.registerCommand("footnote", function(options, content)
   SILE.typesetter.pageTarget = function () return 0xFFFFFF end
   SILE.settings.reset()
   local material = SILE.Commands["vbox"]({}, function()
-    SILE.Commands["font"]({size = "9pt"}, function()
+    SILE.Commands["footnote:font"]({}, function()
       SILE.call("footnote:atstart")
       SILE.call("footnote:counter")
       SILE.process(content)
@@ -52,6 +52,12 @@ SILE.registerCommand("footnote", function(options, content)
   SILE.typesetter = oldT
   insertions.exports:insert("footnote", material)
   SILE.scratch.counters.footnote.value = SILE.scratch.counters.footnote.value + 1
+end)
+
+SILE.registerCommand("footnote:font", function(o,c)
+  SILE.Commands["font"]({size = "9pt"}, function()
+    SILE.process(c)
+  end)
 end)
 
 SILE.registerCommand("footnote:atstart", function(o,c)


### PR DESCRIPTION
Previous code had a hard coded way of setting the foootnote font size to
9pt. The \footnote:atstart command could be fired up to override this,
but that fires only after the value has been set once. Additionally this
makes it hard for a class to customize and still make it easy for the
user to over-ride. A class should be able to set the default font size
while still letting the user run code of their own at start (without
having to manually include the font settings if they don't want to
override them.

Related to #204