### PR TITLE
Rename codepoint to gid

### DIFF
--- a/core/harfbuzz-shaper.lua
+++ b/core/harfbuzz-shaper.lua
@@ -73,7 +73,7 @@ SILE.shapers.harfbuzz = SILE.shapers.base {
     end
     if not nnodevalue.glyphString then nnodevalue.glyphString = {} end
     if not nnodevalue.glyphNames then nnodevalue.glyphNames = {} end
-    table.insert(nnodevalue.glyphString, shapedglyph.codepoint)
+    table.insert(nnodevalue.glyphString, shapedglyph.gid)
     table.insert(nnodevalue.glyphNames, shapedglyph.name)
   end,
   debugVersions = function()

--- a/core/libtexpdf-output.lua
+++ b/core/libtexpdf-output.lua
@@ -50,7 +50,7 @@ SILE.outputters.libtexpdf = {
     -- is actually the shaped x_advance).
     if value.complex then
       for i=1,#(value.items) do
-        local glyph = value.items[i].codepoint
+        local glyph = value.items[i].gid
         local buf = string.char(math.floor(glyph % 2^32 / 2^8)) .. string.char(glyph % 0x100)
         pdf.setstring(cursorX + (value.items[i].x_offset or 0), cursorY + (value.items[i].y_offset or 0), buf, string.len(buf), font, value.items[i].glyphAdvance)
         cursorX = cursorX + value.items[i].width

--- a/packages/font-fallback.lua
+++ b/packages/font-fallback.lua
@@ -25,7 +25,7 @@ SILE.shapers.harfbuzzWithFallback = SILE.shapers.harfbuzz {
         local newItems = SILE.shapers.harfbuzz:shapeToken(chunk, options)
         local startOfNotdefRun = -1
         for i =1,#newItems do
-          if newItems[i].codepoint > 0 then
+          if newItems[i].gid > 0 then
             SU.debug("fonts", "Found glyph '"..newItems[i].text.."'")
             if startOfNotdefRun > -1 then
               shapeQueue[#shapeQueue+1] = {

--- a/src/justenoughharfbuzz.c
+++ b/src/justenoughharfbuzz.c
@@ -195,7 +195,7 @@ int shape (lua_State *L) {
         }
       }
 
-      lua_pushstring(L, "codepoint");
+      lua_pushstring(L, "gid");
       lua_pushinteger(L, glyph_info[j].codepoint);
       lua_settable(L, -3);
       lua_pushstring(L, "index");


### PR DESCRIPTION
The use of codepoint here is confusing since it is actually a glyph id
(HarfBuzz calls it that way probably because the buffer holds actual
code points before shaping).