### PR TITLE
Call book.endPage() function from book.finish()

### DIFF
--- a/classes/book.lua
+++ b/classes/book.lua
@@ -27,6 +27,7 @@ book.newPage = function(self)
 end
 
 book.finish = function ()
+  book.endPage()
   book:writeToc()
   return plain:finish()
 end


### PR DESCRIPTION
Without this the baseclass.endPage() is used to end only the last page
in the book, causing the running headers to show up on all but the last
page. This is fine if you happen to dump a trailing page for binding
purposes with no content anyway, but it that page happens to still have
book content it's a little lonely without headers.