### PR TITLE
Rename undefined language as 'und' rather than 'xx'

### DIFF
--- a/classes/plain.lua
+++ b/classes/plain.lua
@@ -83,7 +83,7 @@ plain.registerCommands = function()
 \define[command=justified]{\set[parameter=document.rskip]\set[parameter=document.spaceskip]}%
 \define[command=rightalign]{\raggedleft{\process\par}}%
 \define[command=em]{\font[style=italic]{\process}}%
-\define[command=nohyphenation]{\font[language=xx]{\process}}%
+\define[command=nohyphenation]{\font[language=und]{\process}}%
 \define[command=raggedright]{\ragged[right=true]{\process}}%
 \define[command=raggedleft]{\ragged[left=true]{\process}}%
 \define[command=center]{\ragged[left=true,right=true]{\process}}%

--- a/documentation/macros.xml
+++ b/documentation/macros.xml
@@ -16,7 +16,7 @@
 <define command="book:sectionfont"><sectionsfont><font size="15pt"><process/></font></sectionsfont></define>
 <define command="book:subsectionfont"><sectionsfont><font size="13pt"><process/></font></sectionsfont></define>
 
-<define command="code"><font family="DejaVu Sans Mono" size="1.5ex" style="roman" language="xx"><process/></font></define>
+<define command="code"><font family="DejaVu Sans Mono" size="1.5ex" style="roman" language="und"><process/></font></define>
 <define command="verbatim:font"><font family="DejaVu Sans Mono" size="9pt"/></define>
 <define command="command"><code><process/></code></define>
 <define command="changed">

--- a/documentation/sile.sil
+++ b/documentation/sile.sil
@@ -824,10 +824,10 @@ SILE hyphenates words based on its current language. (Language is set using the
 variety of languages, and also aims to encode specific typesetting knowledge about
 languages.
 
-SILE comes with a special “language” called \code{xx}, which has no hyphenation
+SILE comes with a special “language” called \code{und}, which has no hyphenation
 patterns available. If you switch to this language, text will not be hyphenated.
 The command \code{\\nohyphenation\{\dots\}} is provided as a shortcut for
-\code{\\font[language=xx]\{\dots\}}.
+\code{\\font[language=und]\{\dots\}}.
 
 Aside from hyphenation, typesetting conventions differ from language to language.
 SILE has basic support for typesetting most languages and scripts. (Again, let me

--- a/examples/usx/usx.sil
+++ b/examples/usx/usx.sil
@@ -3,7 +3,7 @@
 %\grid[spacing=14pt]%
 \set[parameter=linebreak.tolerance,value=5000]%
 \set-counter[id=footnote,display=alpha]%
-\font[language=xx]% Don't hyphenate
+\font[language=und]% Don't hyphenate
 \script[src=packages/xmltricks]%
 \script[src=packages/frametricks]%
 \script[src=packages/raiselower]%

--- a/languages/und.lua
+++ b/languages/und.lua
@@ -1,0 +1,1 @@
+SILE.hyphenator.languages["und"] = {patterns = {}, exceptions = {}};

--- a/languages/xx.lua
+++ b/languages/xx.lua
@@ -1,1 +1,0 @@
-SILE.hyphenator.languages["xx"] = {patterns = {}, exceptions = {}};

--- a/packages/tate.lua
+++ b/packages/tate.lua
@@ -73,7 +73,7 @@ SILE.registerCommand("latin-in-tate", function (options, content)
     latinT.frame = oldT.frame
     latinT:initState()
     SILE.typesetter = latinT
-    SILE.settings.set("document.language", "xx")
+    SILE.settings.set("document.language", "und")
     SILE.settings.set("font.direction", "LTR")
     SILE.process(content)
     nodes = SILE.typesetter.state.nodes
@@ -114,7 +114,7 @@ SILE.registerCommand("tate-chu-yoko", function (options, content)
                             })
   })
   SILE.settings.temporarily(function()
-    SILE.settings.set("document.language", "xx")
+    SILE.settings.set("document.language", "und")
     SILE.settings.set("font.direction", "LTR")
     SILE.call("hbox", {}, content)
     local n = SILE.typesetter.state.nodes[#SILE.typesetter.state.nodes]

--- a/packages/verbatim.lua
+++ b/packages/verbatim.lua
@@ -15,7 +15,7 @@ SILE.registerCommand("verbatim", function(options, content)
     SILE.settings.set("document.lineskip", SILE.nodefactory.newVglue("2pt"))
     SILE.call("verbatim:font")
     SILE.settings.set("document.spaceskip", SILE.length.parse("1spc"))
-    SILE.settings.set("document.language", "xx")
+    SILE.settings.set("document.language", "und")
     -- SILE.settings.set("shaper.spacepattern", '%s') -- XXX Shaper no longer uses this so it was removed
     SILE.process(content)
   end)


### PR DESCRIPTION
Fixes issue #270

This maintains some semblance of compliance with other language tagging
systems as specified by IETF BCP-47.