### PR TITLE
bootstrap.sh: Exit upon commain failure

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 git submodule update --init --recursive --remote
 autoreconf --install
 case `uname` in Darwin*) glibtoolize ;;


### PR DESCRIPTION
If a command, such as git or automake, is missing, there isn't much point in continuing.

`set -e` is [specified by POSIX][1], so we can probably assume it's present on most systems.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#set