### PR TITLE
README.md: Augment instructions for systems using `/usr/local`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ If you are building from a a git clone, start by running the script to setup you
 Once your dependencies are installed, run:
 
     $ ./configure
+
+If your system places 3rd party software in `/usr/local`, you may need to run this instead:
+
+    $ env CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib ./configure
+
+Now you should be able to build and install SILE:
+
+    $ make
     $ make install
 
 This will place the SILE libraries and executable in a sensible location.


### PR DESCRIPTION
For whatever reason, the configure script fails on OpenBSD if
{C,LD}FLAGS aren't manually set to the values below.  Note that env(1)
is used for compatibility with non-Bourne shells, like csh.

---

With that said, I don't think this is an optimal solution. Perhaps it would be better if this behaviour was fixed (assuming it's considered broken), although I know very little about GNU autotools.

In case we want to go that route, here's the actual error I experience when running `./configure`: https://gist.github.com/mreed1/9823cd0d97a1bb337fcb. I'd be happy to provide more info if needed.