### PR TITLE
Call FcConfigSubstitute and FcDefaultSubstitute before FcFontMatch

### DIFF
--- a/src/justenoughfontconfig.c
+++ b/src/justenoughfontconfig.c
@@ -89,8 +89,11 @@ int face_from_options(lua_State* L) {
   FcPatternAddString (p, FC_FAMILY,(FcChar8*) "Times-Roman");
   FcPatternAddString (p, FC_FAMILY,(FcChar8*) "Times");
   FcPatternAddString (p, FC_FAMILY,(FcChar8*) "Helvetica");
+
+  FcConfigSubstitute (NULL, p, FcMatchFont);
+  FcDefaultSubstitute (p);
   matched = FcFontMatch (0, p, &result);
-  
+
   if (FcPatternGetString (matched, FC_FILE, 0, &font_path) != FcResultMatch)
     return 0;
   


### PR DESCRIPTION
According to the [FcFontMatch documentation](https://www.freedesktop.org/software/fontconfig/fontconfig-devel/fcfontmatch.html), fontconfig can return
wrong results if these functions have not been called before.

Note: When running the regression tests on my local machine with
this change, I get some diffs for `bug-264b.sil` and `vertical.sil`.
However, when building SILE from git head without any changes,
I get the exact same errors.