### PR TITLE
Fix base url so relative links work

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ markdown: kramdown
 highlighter: rouge
 kramdown:
   input: GFM
+baseurl: "/"
 paginate: 5
 paginate_path: "blog/page:num"
 gems:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,7 @@
       <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
       <title>SILE – {{ page.title }}</title>
       <meta name="viewport" content="width=device-width">
+      <base href='{{ site.baseurl }}'>
 
       <!-- syntax highlighting CSS -->
       <link rel="stylesheet" href="css/syntax.css">


### PR DESCRIPTION
Fixes #294

This does _not_ allow the site to be hosted under forks on Github Pages
as it should because Jekyll there does not set the value correctly, but
it does allow a local Jekyll instance to be hosted under a subdirectory
if you can set the `--baseurl` flag. There are some other issues with
that, but this should restore the main site to full functionality.