### PR TITLE
Don't reset spaceskip inside \justified

### DIFF
--- a/classes/plain.lua
+++ b/classes/plain.lua
@@ -106,7 +106,6 @@ SILE.registerCommand("ragged", function(options,c)
     if options.right then SILE.settings.set("document.rskip", SILE.nodefactory.hfillGlue) end
     SILE.settings.set("typesetter.parfillskip", SILE.nodefactory.zeroGlue)
     SILE.settings.set("document.parindent", SILE.nodefactory.zeroGlue)
-    SILE.settings.set("document.spaceskip", SILE.length.parse("1spc"))
     SILE.process(c)
     SILE.call("par")
   end)

--- a/classes/plain.lua
+++ b/classes/plain.lua
@@ -80,7 +80,7 @@ plain.registerCommands = function()
 \define[command=goodbreak]{\penalty[penalty=-500]}%
 \define[command=eject]{\vfill\break}%
 \define[command=supereject]{\vfill\penalty[penalty=-20000]}%
-\define[command=justified]{\set[parameter=document.rskip]\set[parameter=document.spaceskip]{\process\par}}%
+\define[command=justified]{\set[parameter=document.rskip]{\process\par}}%
 \define[command=rightalign]{\raggedleft{\process\par}}%
 \define[command=em]{\font[style=Italic]{\process}}%
 \define[command=strong]{\font[weight=600]{\process}}%


### PR DESCRIPTION
This is a revert of what seems to be a stay setting added in 20d0617.
Reseting the spaceskip value to the font default value for just one
environment but not all the similar ones is inconsistent at best and I
can't figure out what problem it solves. Either this should be done in
all the justification environments so that users come to expect the
value to be changed or (as in this commit) it should be left alone and
whatever gets set in the parent node should carry through to justified
environments.