### PR TITLE
SILE: font: add support for HyphenChar parameter

### DIFF
--- a/core/font.lua
+++ b/core/font.lua
@@ -35,6 +35,10 @@
           SILE.settings.set("font.script", lang.defaultScript)
         end
       end
+      if (options.hyphenchar) then
+        -- must be in the form of, for example, "-" or "U+2010" or "0x2010" (Unicode hex codepoint)
+        SILE.settings.set("font.hyphenchar", SU.utf8charfromcodepoint(options.hyphenchar))
+      end
 
       if (type(content)=="function" or content[1]) then
         SILE.process(content)
@@ -51,6 +55,7 @@ SILE.settings.declare({name = "font.style", type = "string", default = ""})
 SILE.settings.declare({name = "font.direction", type = "string", default = ""})
 SILE.settings.declare({name = "font.filename", type = "string", default = ""})
 SILE.settings.declare({name = "font.features", type = "string", default = ""})
+SILE.settings.declare({name = "font.hyphenchar", type = "string", default = "-"})
 SILE.settings.declare({name = "document.language", type = "string", default = "en"})
 
 SILE.fontCache = {}
@@ -79,6 +84,7 @@ SILE.font = {loadDefaults = function(options)
     end
   end
   if not options.features then options.features = SILE.settings.get("font.features") end
+  if not options.hyphenchar then options.hyphenchar = SILE.settings.get("font.hyphenchar") end
   return options
 end,
   cache = function(options, callback)

--- a/core/hyphenator-liang.lua
+++ b/core/hyphenator-liang.lua
@@ -97,7 +97,7 @@ local hyphenateNode = function(n)
           end
         end
         if not (j == #breaks) then
-          d = SILE.nodefactory.newDiscretionary({ prebreak = SILE.shaper:createNnodes("-", n.options) })
+          d = SILE.nodefactory.newDiscretionary({ prebreak = SILE.shaper:createNnodes(SILE.settings.get("font.hyphenchar"), n.options) })
           d.parent = n
           table.insert(newnodes, d)
          --table.insert(newnodes, SILE.nodefactory.newPenalty({ value = SILE.settings.get("typesetter.hyphenpenalty") }))
@@ -118,7 +118,7 @@ showHyphenationPoints = function (word, language)
     _hyphenators[language] = {minWord = 5, leftmin = 2, rightmin = 2, trie = {}, exceptions = {} };
     loadPatterns(_hyphenators[language], language)
   end
-  return SU.concat(_hyphenate(_hyphenators[language], word), "-")
+  return SU.concat(_hyphenate(_hyphenators[language], word), SILE.settings.get("font.hyphenchar"))
 end
 
 SILE.hyphenate = function (nodelist)

--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -164,6 +164,22 @@ utilities.codepoint = function (uchar)
   return val
 end
 
+utilities.utf8charfromcodepoint = function (codepoint)
+  local val = codepoint
+  local cp = val
+  local hex = (cp:match("[Uu]%+(%x+)") or cp:match("0[xX](%x+)"))
+  if hex then
+    cp = tonumber("0x"..hex)
+  elseif tonumber(cp) then
+    cp = tonumber(cp)
+  end
+
+  if type(cp) == "number" then
+    val = SU.utf8char(cp)
+  end
+  return val
+end
+
 utilities.utf8codes = function (ustr)
   local pos = 1
   return function()

--- a/documentation/sile.sil
+++ b/documentation/sile.sil
@@ -824,6 +824,11 @@ SILE hyphenates words based on its current language. (Language is set using the
 variety of languages, and also aims to encode specific typesetting knowledge about
 languages.
 
+The default hyphen character is “-”, which can be tweaked by the \code{\\font}
+parameter \code{hyphenchar}. It accepts a Unicode character or Unicode codepoint
+in \code{[Uu]+<code>} or Hexadecimal \code{0[Xx]<code>} format – for instance
+\code{\\font[family=Rachana,language=ml,hyphenchar=U+200C]}.
+
 SILE comes with a special “language” called \code{und}, which has no hyphenation
 patterns available. If you switch to this language, text will not be hyphenated.
 The command \code{\\nohyphenation\{\dots\}} is provided as a shortcut for

--- a/packages/unichar.lua
+++ b/packages/unichar.lua
@@ -1,13 +1,7 @@
 SILE.registerCommand("unichar", function(options, content)
   local cp = content[1]
   if type(cp) ~= "string" then SU.error("Bad argument to \\unicode") end
-  hex = (cp:match("[Uu]%+(%x+)") or cp:match("0[xX](%x+)"))
-  if hex then
-    cp = tonumber("0x"..hex)
-  elseif tonumber(cp) then
-    cp = tonumber(cp)
-  end
-  SILE.typesetter:typeset(SU.utf8char(cp))
+  SILE.typesetter:typeset(SU.utf8charfromcodepoint(cp))
 end)
 
 return { documentation = [[\begin{document}

--- a/tests/malayalam.sil
+++ b/tests/malayalam.sil
@@ -1,0 +1,16 @@
+\begin[class=book]{document}%
+\script[src=packages/frametricks]
+\begin[first-content-frame=column1]{pagetemplate}
+  \frame[id=gutter,width=3%]
+  \frame[id=title, top=top(content), bottom=top(title)+5%, left=left(content), right=right(content),next=column1]
+  \frame[id=column1,left=left(content),top=bottom(title)+2,bottom=bottom(content),width=53pt]
+\end{pagetemplate}
+\par
+% Malayalam uses non-visible hyphen (U+200C - ZWJ)
+\font[family=Rachana,language=ml,size=12pt,hyphenchar=U+200C] %Traditional orthography font https://smc.org.in/fonts
+
+% Instead of visible hyphen "-", non-visible hyphen will be used on breaking
+\noindent{}
+സംസാരിച്ചിരിക്കുക 
+
+\end{document}


### PR DESCRIPTION
Many scripts/languages use different hyphenating character than "-". For instance Malayalam prefers non-visible hyphen. XeTeX has support for specifying the preferred hyphen per font via fontspec. Add similar functionality to SILE.
One question: it seems setting `font.hyphenchar` affects subsequent different font/language text as well unless explicitly set to something else. Is this correct, or is there a better way?

Please note: this is my first attempt to make changes to SILE and in Lua - would be great to get your feedback and whether it could be implemented better.