### PR TITLE
Fix change from ee97145d to only be warning so we don't kill existing working docs

### DIFF
--- a/core/languages.lua
+++ b/core/languages.lua
@@ -8,7 +8,7 @@ SILE.languageSupport = {
     if ok then return end
     ok, fail = pcall(function () SILE.require("languages/"..language) end)
     if fail then
-      SU.error("Error loading language "..language..": "..fail)
+      SU.warn("Error loading language "..language..": "..fail)
     end
   end,
   compile = function(language)


### PR DESCRIPTION
Even in the SILE source tree we have tons of `font[language=ar]` etc. calls for languages that don't have specific setups (yet). This at  least works to pass some data about the text through to Harfbuzz etc, blocking compilation altogether for languages we don't have yet is worse than failing gracefully.