### PR TITLE
Pass objects to TOC

### DIFF
--- a/classes/book.lua
+++ b/classes/book.lua
@@ -67,6 +67,7 @@ SILE.registerCommand("right-running-head", function(options, content)
 end, "Text to appear on the top of the right page");
 
 SILE.registerCommand("book:sectioning", function (options, content)
+  local content = SU.subContent(content)
   local level = SU.required(options, "level", "book:sectioning")
   SILE.call("increment-multilevel-counter", {id = "sectioning", level = options.level})
   SILE.call("tocentry", {level = options.level}, content)

--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -132,6 +132,30 @@ function utilities.allCombinations(options)
   end)
 end
 
+-- Flatten content trees into just the string components (allows passing
+-- objects with complex structures to functions that need plain strings)
+function utilities.contentToString(content)
+  out = ""
+  for key, val in pairs(content) do
+    if type(key) == "number" and type(val) == "string" then
+      out = out .. val
+    end
+  end
+  return out
+end
+
+-- Strip the top level command off a content object and keep only the child
+-- items — assuming that the current command is taking care of itself
+function utilities.subContent(content)
+  out = { id="stuff" }
+  for key, val in pairs(content) do
+    if type(key) == "number" then
+      out[#out+1] = val
+    end
+  end
+  return out
+end
+
 -- Unicode-related utilities
 utilities.utf8char = function (c)
     if     c < 128 then

--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -40,7 +40,8 @@ if SILE.Commands.tocentry then
   local oldtoc = SILE.Commands.tocentry
   SILE.Commands.tocentry = function (o,c)
     SILE.call("pdf:destination", { name = "dest"..SILE.scratch.pdf.dc } )
-    SILE.call("pdf:bookmark", { title = c[1], dest = "dest"..SILE.scratch.pdf.dc, level = o.level })
+    local title = SU.contentToString(c)
+    SILE.call("pdf:bookmark", { title = title, dest = "dest"..SILE.scratch.pdf.dc, level = o.level })
     oldtoc(o,c)
     SILE.scratch.pdf.dc = SILE.scratch.pdf.dc + 1
   end

--- a/packages/tableofcontents.lua
+++ b/packages/tableofcontents.lua
@@ -44,7 +44,7 @@ SILE.registerCommand("tableofcontents:item", function (o,c)
   SILE.settings.temporarily(function ()
     SILE.settings.set("typesetter.parfillskip", SILE.nodefactory.zeroGlue)
     SILE.call("tableofcontents:level"..o.level.."item", {}, function()
-      SILE.process({c})
+      SILE.process(c)
       -- Ideally, leaders
       SILE.call("dotfill")
       SILE.typesetter:typeset(o.pageno)
@@ -56,12 +56,11 @@ SILE.registerCommand("tocentry", function (options, content)
   SILE.call("info", {
     category = "toc",
     value = {
-      label = content[1],
+      label = content,
       level = (options.level or 1)
     }
   })
 end)
-
 
 return {
   exports = {writeToc = writeToc, moveTocNodes = moveNodes},


### PR DESCRIPTION
This takes a slightly different approach passing content to the TOC.

- The **original** model: Parse the entry down to a single string item, pass it to the TOC, then use it as a string for the PDF index and wrap it it an object again to typeset.

- The **new** model: Pass the original entry as-is to the TOC. Then reduce it to a string (by walking the entire object) for the PDF index and use the whole object minus the top level function to typeset the contents.

This approach allows chapter titles to include extra code (such as emphasized words, or in my first use case discretionary break points) in the chapter title string that actually gets used in the TOC entry. Of course having SILE code passed along to the TOC works fine for typesetting it, but not so much for cramming into the PDF index. For that I wrote a couple utility functions to reduce content structures down to a string or just strip the top level command for various use cases. 