### PR TITLE
Add \strong for ease of document format conversion

### DIFF
--- a/classes/markdown.lua
+++ b/classes/markdown.lua
@@ -36,14 +36,9 @@ SILE.registerCommand("sect3", function(options, content)
   SILE.call("subsection", options, content)
 end)
 
-SILE.registerCommand("strong", function(options, content)
-  SILE.call("em", options, content)
-end)
-
 SILE.registerCommand("emphasis", function(options, content)
   SILE.call("em", options, content)
 end)
-
 
 SILE.registerCommand("bulletlist", function(options, content)
   SILE.process(content)

--- a/classes/plain.lua
+++ b/classes/plain.lua
@@ -82,7 +82,8 @@ plain.registerCommands = function()
 \define[command=supereject]{\vfill\penalty[penalty=-20000]}%
 \define[command=justified]{\set[parameter=document.rskip]\set[parameter=document.spaceskip]}%
 \define[command=rightalign]{\raggedleft{\process\par}}%
-\define[command=em]{\font[style=italic]{\process}}%
+\define[command=em]{\font[style=Italic]{\process}}%
+\define[command=strong]{\font[weight=600]{\process}}%
 \define[command=nohyphenation]{\font[language=und]{\process}}%
 \define[command=raggedright]{\ragged[right=true]{\process}}%
 \define[command=raggedleft]{\ragged[left=true]{\process}}%


### PR DESCRIPTION
Converting documents between formats (e.g. with Pandoc) is a kettle of
fish, but having a few standard markup tags available that have obvious
correlations in other markup languages makes the process a lot easier.
The name of `strong` was chosen to pair with our existing `em` also used
in HTML (as opposed to `textbf` which might have paired with `textit` if
we were using LaTeX as a reference).