### PR TITLE
Update metrics so test is symptomatic of bug

### DIFF
--- a/tests/bug-301.sil
+++ b/tests/bug-301.sil
@@ -1,7 +1,7 @@
 \begin[papersize=a7,class=book]{document}
 \script[src=packages/linespacing]
 \set[parameter=linespacing.method,value=fit-font]
-\set[parameter=linespacing.fit-font.extra-space,value=1.15ex plus 0.5pt minus 0.5pt]
+\set[parameter=linespacing.fit-font.extra-space,value=0.6ex plus 0.5pt minus 0.5pt]
 All the paragraphs in this test should be left justified and all the signatures should end up ragged-left.
 
 \hfill The undersigned,


### PR DESCRIPTION
See #301

At some point SILE changed the way it handled leading and the values
needed to re-create a similar document with things in the places that
show the problems changed quite a bit. This should create a document
that is symptomatic again.