### PR TITLE
Restore (and fix) function to multiply lengths

### DIFF
--- a/core/length.lua
+++ b/core/length.lua
@@ -75,6 +75,20 @@ _length = std.object {
     return result
   end,
    
+  __div = function(self, other)
+    local result = _length {}
+    result:fromLengthOrNumber(self)
+    result = result:absolute()
+    if type(other) == "table" then
+      SU.error("Attempt to divide two lengths together")
+    else
+      result.length = result.length / other
+      result.stretch = result.stretch / other
+      result.shrink = result.shrink / other
+    end
+    return result
+  end,
+
   __lt = function (self, other)
     return (self-other).length < 0
   end,

--- a/core/length.lua
+++ b/core/length.lua
@@ -61,18 +61,19 @@ _length = std.object {
     return result
   end,
 
-  -- __mul = function(self, other)
-  --   local result = _length {}
-  --   result:fromLengthOrNumber(self)
-  --   if type(other) == "table" then
-  --     SU.error("Attempt to multiply two lengths together")
-  --   else
-  --     result.length = result.length * other
-  --     result.stretch = result.stretch * other
-  --     result.shrink = result.shrink * other
-  --   end
-  --   return result
-  -- end,
+  __mul = function(self, other)
+    local result = _length {}
+    result:fromLengthOrNumber(self)
+    result = result:absolute()
+    if type(other) == "table" then
+      SU.error("Attempt to multiply two lengths together")
+    else
+      result.length = result.length * other
+      result.stretch = result.stretch * other
+      result.shrink = result.shrink * other
+    end
+    return result
+  end,
    
   __lt = function (self, other)
     return (self-other).length < 0


### PR DESCRIPTION
SILE may not have a use for these internally, but I keep running into times it would be nice to be able to treat a length as a number that can be multiplied and dived by some increment. Rather than having to manually convert to a number every time, it seems to make sense just to teach Lua how to handle × and ÷ operations on lengths. Given that it already handles + and -, this seem like the most expected behavior from an end user perspective.