### PR TITLE
Allow customization of TOC with a footer to match header

### DIFF
--- a/packages/tableofcontents.lua
+++ b/packages/tableofcontents.lua
@@ -38,6 +38,7 @@ SILE.registerCommand("tableofcontents", function (options, content)
     local item = toc[i]
     SILE.call("tableofcontents:item", {level = item.level, pageno= item.pageno}, item.label)
   end
+  SILE.call("tableofcontents:footer")
 end)
 
 SILE.registerCommand("tableofcontents:item", function (o,c)
@@ -72,6 +73,7 @@ SILE.doTexlike([[%
 \define[command=tableofcontents:notocmessage]{\tableofcontents:headerfont{Rerun SILE to process table of contents!}}%
 \define[command=tableofcontents:headerfont]{\font[size=24pt,weight=800]{\process}}%
 \define[command=tableofcontents:header]{\par\noindent\tableofcontents:headerfont{\tableofcontents:title}\medskip}%
+\define[command=tableofcontents:footer]{}%
 \define[command=tableofcontents:level1item]{\bigskip\noindent\font[size=14pt,weight=800]{\process}\medskip}%
 \define[command=tableofcontents:level2item]{\noindent\font[size=12pt]{\process}\medskip}%
 \define[command=tableofcontents:level3item]{\indent\font[size=10pt]{\process}\smallskip}%


### PR DESCRIPTION
We had a command for \tableofcontents:header to make it easy for a class
to typeset some stuff up there. This is sometimes where the command for
opening a new page (if any) is placed. Unfortunately we didn't have a
matching footer one. This adds one and sets it up to add flexibility to
the layouts a class can accomplish without having to modify the document
content and without having to do too many antics with redefining
standard commands.

I have documents that I want to typeset using the same template
(generated by Pandoc) but with different classes and sometimes the TOC
will take up a full page and sometime not. Having to change the body
content of the document is not an option in these cases and the most
logical place to put it is the same place where the control for starting
on a blank page or not goes.

This likely didn't get noticed before because it is often used alongside
the \chapter command in the book class which starts a new page by
defalt.