### PR TITLE
OS X (< 10.8): Check if compiler knows about modules (@import)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ case $host_os in
     save_LIBS="$LIBS"
     LIBS="$LIBS -framework AppKit"
     AC_LANG_PUSH([Objective C])
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([[]],[[]])],
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[@import AppKit;]],[[]])],
       [
       have_appkit=yes
       AC_DEFINE([APPKIT], [1], [Build using AppKit])


### PR DESCRIPTION
This change should fix building for OS X < 10.8, at the expense of disabling AppKit support on those systems.

I successfully tested this with Homebrew on OS X 10.7.5, using the following equivalent patch to `configure`:

```
--- configure~  2016-08-31 09:33:03.000000000 +0300
+++ configure   2016-10-28 11:28:14.000000000 +0300
@@ -13446,7 +13446,7 @@

 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
+@import AppKit;
 int
 main ()
 {

```

Background information is available at [Apple developer web site](https://developer.apple.com/library/content/documentation/Xcode/Conceptual/WhatsNewXcode-Archive/Articles/xcode_5_0.html), particularly "Modules for system frameworks" under the heading "Compiler".
