### PR TITLE
Allow classes to be loaded from non hard-coded paths

### DIFF
--- a/classes/bible.lua
+++ b/classes/bible.lua
@@ -1,4 +1,4 @@
-local plain = SILE.require("classes/plain")
+local plain = SILE.require("plain", "classes")
 local bible = plain { id = "bible", base = plain }
 if not(SILE.scratch.headers) then SILE.scratch.headers = {}; end
 

--- a/classes/book.lua
+++ b/classes/book.lua
@@ -1,4 +1,4 @@
-local plain = SILE.require("classes/plain")
+local plain = SILE.require("plain", "classes")
 local book = plain { id = "book" }
 book:loadPackage("masters")
 book:defineMaster({ id = "right", firstContentFrame = "content", frames = {

--- a/classes/diglot.lua
+++ b/classes/diglot.lua
@@ -1,4 +1,4 @@
-local plain = SILE.require("classes/plain")
+local plain = SILE.require("plain", "classes")
 local diglot = std.tree.clone(plain)
 SILE.require("packages/counters")
 SILE.scratch.counters.folio = { value = 1, display = "arabic" }

--- a/classes/docbook.lua
+++ b/classes/docbook.lua
@@ -1,4 +1,4 @@
-local plain = SILE.require("classes/plain")
+local plain = SILE.require("plain", "classes")
 docbook = plain { id = "docbook" }
 SILE.scratch.docbook = {
   seclevel = 0,

--- a/classes/jbook.lua
+++ b/classes/jbook.lua
@@ -1,4 +1,4 @@
-local book = SILE.require("classes/book")
+local book = SILE.require("book", "classes")
 local jbook = book { id = "jbook", base = book }
 
 SILE.call("bidi-off")

--- a/classes/jplain.lua
+++ b/classes/jplain.lua
@@ -1,5 +1,5 @@
 -- Basic! Transitional! In development! Not very good! Don't use it!
-local plain = SILE.require("classes/plain")
+local plain = SILE.require("plain", "classes")
 local jplain = plain { id = "jplain", base = plain }
 
 SILE.call("bidi-off")

--- a/classes/markdown.lua
+++ b/classes/markdown.lua
@@ -22,7 +22,7 @@ SILE.inputs.markdown = {
 
 SILE.require("packages/url")
 
-local book = SILE.require("classes/book")
+local book = SILE.require("book", "classes")
 
 SILE.registerCommand("sect1", function(options, content)
   SILE.call("chapter", options, content)

--- a/classes/pecha.lua
+++ b/classes/pecha.lua
@@ -1,4 +1,4 @@
-local plain = SILE.require("classes/plain")
+local plain = SILE.require("plain", "classes")
 local pecha = plain { id = "pecha", base = plain }
 
 pecha:declareFrame("content", {left = "5%pw",  right = "95%pw",  top = "5%ph",  bottom = "90%ph" })

--- a/classes/triglot.lua
+++ b/classes/triglot.lua
@@ -1,4 +1,4 @@
-local plain = SILE.require("classes/book")
+local plain = SILE.require("book", "classes")
 local diglot = std.tree.clone(plain)
 SILE.require("packages/counters")
 SILE.scratch.counters.folio = { value = 1, display = "arabic" }

--- a/core/inputs-common.lua
+++ b/core/inputs-common.lua
@@ -2,7 +2,7 @@ SILE.inputs.common = {
   init = function(fn, t)
     local dclass = t.attr.class or "plain"
     t.attr.papersize = t.attr.papersize or "a4"
-    SILE.documentState.documentClass = SILE.require("classes/"..dclass)
+    SILE.documentState.documentClass = SILE.require(dclass, "classes")
     for k,v in pairs(t.attr) do
       if SILE.documentState.documentClass.options[k] then
         SILE.documentState.documentClass.options[k](v)

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -59,6 +59,10 @@ end
 SILE.require = function (dependency, pathprefix)
   local file = SILE.resolveFile(dependency..".lua", pathprefix)
   if file then return require(file:gsub(".lua$","")) end
+  if pathprefix then
+    local status, lib = pcall(require, std.io.catfile(pathprefix, dependency))
+    return status and lib or require(dependency)
+  end
   return require(dependency)
 end
 

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -56,8 +56,8 @@ SILE.init = function()
   end
 end
 
-SILE.require = function(dependency)
-  local file = SILE.resolveFile(dependency..".lua")
+SILE.require = function (dependency, pathprefix)
+  local file = SILE.resolveFile(dependency..".lua", pathprefix)
   if file then return require(file:gsub(".lua$","")) end
   return require(dependency)
 end
@@ -180,7 +180,7 @@ local function file_exists(filename)
    if file ~= nil then io.close(file) return true else return false end
 end
 
-function SILE.resolveFile(filename)
+function SILE.resolveFile(filename, pathprefix)
   if file_exists(filename) then return filename end
   if file_exists(filename..".sil") then return filename..".sil" end
   if not SILE.masterFilename then return nil end
@@ -188,6 +188,11 @@ function SILE.resolveFile(filename)
   local dirname = SILE.masterFilename:match("(.-)[^%/]+$")
   for k in SU.gtoke(dirname..";"..tostring(os.getenv("SILE_PATH")), ";") do
     if k.string then
+      if pathprefix then
+        local file = std.io.catfile(k.string, pathprefix, filename)
+        if file_exists(file) then return file end
+        if file_exists(file..".sil") then return file..".sil" end
+      end
       local file = std.io.catfile(k.string, filename)
       if file_exists(file) then return file end
       if file_exists(file..".sil") then return file..".sil" end

--- a/documentation/sile.sil
+++ b/documentation/sile.sil
@@ -2041,7 +2041,7 @@ how we set up the inheritance:
 
 \begin{verbatim}
 \line
-local book = SILE.require("classes/book")
+local book = SILE.require("book", "classes")
 local bringhurst = book \{ id = "bringhurst" \}
 ...
 return bringhurst
@@ -2584,7 +2584,7 @@ frames:
 
 \begin{verbatim}
 \line
-local plain = SILE.require("classes/plain");
+local plain = SILE.require("plain", "classes");
 local diglot = std.tree.clone(plain);
 SILE.require("packages/counters");
 SILE.scratch.counters.folio = \{ value = 1, display = "arabic" \};
@@ -2965,7 +2965,7 @@ Here’s how to do it.
 \line
 require("core/sile")
 SILE.outputFilename = "byhand.pdf"
-local plain = require("classes/plain")
+local plain = require("plain", "classes")
 SILE.documentState.documentClass = plain;
 local ff = plain:init()
 SILE.typesetter:init(ff)

--- a/examples/byhand.lua
+++ b/examples/byhand.lua
@@ -4,7 +4,7 @@ package.cpath = package.cpath .. ";core/?.so;/usr/local/lib/sile/?.so;"
 require("core/sile")
 SILE.init()
 SILE.outputFilename="byhand.pdf"
-local plain = require("classes/plain")
+local plain = require("plain", "classes")
 plain.options.papersize("a4")
 SILE.documentState.documentClass = plain;
 local ff = plain:init()

--- a/examples/greek-lexicon/classes/perseus.lua
+++ b/examples/greek-lexicon/classes/perseus.lua
@@ -1,4 +1,4 @@
-local plain = SILE.require("classes/plain");
+local plain = SILE.require("plain", "classes");
 local perseus = plain { id = "perseus" };
 SILE.scratch.perseus = {}
 perseus:declareFrame("a",    { left = "8.3%pw",          right = "48%pw",            top = "11.6%ph",        bottom = "80%ph",         next="b" });

--- a/examples/usx/classes/usx.lua
+++ b/examples/usx/classes/usx.lua
@@ -1,4 +1,4 @@
-local bible = SILE.require("classes/bible");
+local bible = SILE.require("bible", "classes");
 local usx = bible { id = "usx", base = bible };
 
 SILE.registerCommand("para", function (options, content)

--- a/sile.in
+++ b/sile.in
@@ -1,6 +1,11 @@
 #!@LUA@
-package.path = (os.getenv("SILE_PATH") and
-os.getenv("SILE_PATH").."/?.lua" or "") .. ';?.lua;@SILE_PATH@/?.lua;@SILE_PATH@/lua-libraries/?.lua;@SILE_PATH@/lua-libraries/?/init.lua;lua-libraries/?.lua;lua-libraries/?/init.lua;' .. package.path
+package.path = '?.lua;@SILE_PATH@/?.lua;@SILE_PATH@/lua-libraries/?.lua;@SILE_PATH@/lua-libraries/?/init.lua;lua-libraries/?.lua;lua-libraries/?/init.lua;' .. package.path
+local pathvar = os.getenv("SILE_PATH")
+if pathvar then
+	for path in string.gmatch(pathvar, "[^;]+") do
+		package.path =  path .. "/?.lua;" .. package.path
+	end
+end
 package.cpath = package.cpath .. ";core/?.@SHARED_LIB_EXT@;@SILE_LIB_PATH@/?.@SHARED_LIB_EXT@;"
 SILE = require("core/sile")
 io.stdout:setvbuf 'no'

--- a/tests/bug-337.lua
+++ b/tests/bug-337.lua
@@ -2,7 +2,7 @@ SILE.registerCommand("printPaperInPoints", function(o,c)
   SILE.typesetter:typeset(("%.0f x %.0f"):format(SILE.toPoints("100%ph"), SILE.toPoints("100%pw")))
 end)
 
-local book = SILE.require("classes/book")
+local book = SILE.require("book", "classes")
 book:loadPackage("masters")
 book:defineMaster({ id="right", firstContentFrame="content", frames={
   content = { left="0", right="100%pw", top="0", bottom="top(folio)" },

--- a/tests/classes/testsidenote.lua
+++ b/tests/classes/testsidenote.lua
@@ -1,4 +1,4 @@
-local plain = SILE.require("classes/plain")
+local plain = SILE.require("plain", "classes")
 local testsidenote = plain { id = "testsidenote" }
 
 local gutterWidth = "3%pw"

--- a/tests/classes/testtwocol.lua
+++ b/tests/classes/testtwocol.lua
@@ -1,4 +1,4 @@
-local plain = SILE.require("classes/plain")
+local plain = SILE.require("plain", "classes")
 local testtwocols = plain { id = "testtwocols" }
 
 local gutterWidth = "3%pw"


### PR DESCRIPTION
The current system demands that any custom classes reside in a specific place relative to the current document. This makes it impossible to include a toolkit in a project in just one folder, you have to pollute the namespace with several folders. This makes it possible to use classes that are in user specified locations so they can even be outside the current directory (referencing a common toolkit folder) or whatever.