### PR TITLE
Pdf external links

### DIFF
--- a/examples/hyperlink.sil
+++ b/examples/hyperlink.sil
@@ -1,0 +1,4 @@
+\begin[papersize=a5]{document}
+\script[src=packages/url]
+Have you tried \href[src="http://sile-typesetter.org/"]{The SILE Typesetter} yet?
+\end{document}

--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -61,6 +61,7 @@ end)
 
 SILE.registerCommand("pdf:link", function (options, content)
   local dest = SU.required(options, "dest", "pdf:link")
+  local target = options.external and "/Type/Action/S/URI/URI" or "/S/GoTo/D"
   local llx, lly
   SILE.typesetter:pushHbox({
     value = nil,
@@ -82,7 +83,7 @@ SILE.registerCommand("pdf:link", function (options, content)
     width = 0,
     depth = 0,
     outputYourself = function (self,typesetter)
-      local d = "<</Type/Annot/Subtype/Link/C [ 1 0 0 ]/A<</S/GoTo/D(" .. dest .. ")>>>>"
+      local d = "<</Type/Annot/Subtype/Link/C [ 1 0 0 ]/A<<" .. target .. "(" .. dest .. ")>>>>"
       pdf.end_annotation(d, llx, lly, typesetter.frame.state.cursorX, SILE.documentState.paperSize[2] -typesetter.frame.state.cursorY + hbox.height)
     end
   })

--- a/packages/url.lua
+++ b/packages/url.lua
@@ -1,4 +1,7 @@
 SILE.require("packages/verbatim")
+local pdf
+pcall(function() pdf = require("justenoughlibtexpdf") end)
+if pdf then SILE.require("packages/pdf") end
 
 local inputfilter = SILE.require("packages/inputfilter").exports
 
@@ -18,6 +21,18 @@ local urlFilter = function (node, content, breakpat)
   end
   return result
 end
+
+SILE.registerCommand("href", function (options, content)
+  if not pdf then return SILE.process(content) end
+  if options.src then
+    SILE.call("pdf:link", { dest = options.src, external = true }, content)
+  else
+    options.src = content[1]
+    local breakpat = options.breakpat or "/"
+    content = inputfilter.transformContent(content, urlFilter, breakpat)
+    SILE.call("pdf:link", { dest = options.src }, content)
+  end
+end)
 
 SILE.registerCommand("url", function (options, content)
   local breakpat = options.breakpat or "/"


### PR DESCRIPTION
This adds an `\href` command to the *url* package that can be used to make links to external URI's.