### PR TITLE
What comes in must go out

### DIFF
--- a/core/break.lua
+++ b/core/break.lua
@@ -551,9 +551,9 @@ end
 
 function lineBreak:dumpActiveRing()
   local p = self.activeListHead
-  io.write("\n")
+  io.stderr:write("\n")
   repeat
-    if p == self.r then io.write("-> ") else io.write("   ") end
+    if p == self.r then io.stderr:write("-> ") else io.stderr:write("   ") end
     print(lineBreak:describeBreakNode(p))
     p = p.next
   until p == self.activeListHead

--- a/core/inputs-common.lua
+++ b/core/inputs-common.lua
@@ -1,9 +1,9 @@
 SILE.inputs.common = {
-  init = function(fn, t)
-    local dclass = t.attr.class or "plain"
-    t.attr.papersize = t.attr.papersize or "a4"
+  init = function(doc, tree)
+    local dclass = tree.attr.class or "plain"
+    tree.attr.papersize = tree.attr.papersize or "a4"
     SILE.documentState.documentClass = SILE.require(dclass, "classes")
-    for k,v in pairs(t.attr) do
+    for k,v in pairs(tree.attr) do
       if SILE.documentState.documentClass.options[k] then
         SILE.documentState.documentClass.options[k](v)
       end
@@ -39,11 +39,11 @@ SILE.process = function(input)
 end
 
 -- Just a simple one-level find. We're not reimplementing XPath here.
-SILE.findInTree = function (t, tag)
-  for i=1, #t do
-    if type(t[i]) == "string" then
-    elseif t[i].tag == tag then
-      return t[i]
+SILE.findInTree = function (tree, tag)
+  for i=1, #tree do
+    if type(tree[i]) == "string" then
+    elseif tree[i].tag == tag then
+      return tree[i]
     end
   end
 end

--- a/core/inputs-common.lua
+++ b/core/inputs-common.lua
@@ -14,7 +14,15 @@ SILE.inputs.common = {
     package.path = dirname.."?;"..dirname.."?.lua;"..package.path
 
     if not SILE.outputFilename and SILE.masterFilename then
-      SILE.outputFilename = string.match(SILE.masterFilename,"(.+)%..-$")..".pdf"
+      -- TODO: This hack works on *nix systems because /dev/stdout is usable as
+      -- a filename to refer to STDOUT. Libtexpdf works fine with this, but it's
+      -- not going to work on Windows quite the same way. Normal filnames will
+      -- still work but explicitly using piped streams won't.
+      if SILE.masterFilename == "-" then
+        SILE.outputFilename = "/dev/stdout"
+      else
+        SILE.outputFilename = string.match(SILE.masterFilename,"(.+)%..-$")..".pdf"
+      end
     end
     local ff = SILE.documentState.documentClass:init()
     SILE.typesetter:init(ff)

--- a/core/inputs-texlike.lua
+++ b/core/inputs-texlike.lua
@@ -91,17 +91,14 @@ local function massage_ast(t,doc)
   return t
 end
 
-function SILE.inputs.TeXlike.process(fn)
-  local fh = io.open(fn)
-  resetCache()
-  local doc = fh:read("*all")
-  local t = SILE.inputs.TeXlike.docToTree(doc)
+function SILE.inputs.TeXlike.process(doc)
+  local tree = SILE.inputs.TeXlike.docToTree(doc)
   local root = SILE.documentState.documentClass == nil
   if root then
-    if not(t.tag == "document") then SU.error("Should begin with \\begin{document}") end
-    SILE.inputs.common.init(fn, t)
+    if not(tree.tag == "document") then SU.error("Should begin with \\begin{document}") end
+    SILE.inputs.common.init(doc, tree)
   end
-  SILE.process(t)
+  SILE.process(tree)
   if root and not SILE.preamble then
     SILE.documentState.documentClass:finish()
   end
@@ -116,14 +113,14 @@ end
 SILE.inputs.TeXlike.rebuildParser()
 
 function SILE.inputs.TeXlike.docToTree(doc)
-  local t = epnf.parsestring(_parser, doc)
+  local tree = epnf.parsestring(_parser, doc)
   -- a document always consists of one stuff
-  t = t[1][1]
-  if t.id == "text" then t = {t} end
-  if not t then return end
+  tree = tree[1][1]
+  if tree.id == "text" then tree = {tree} end
+  if not tree then return end
   resetCache()
-  t = massage_ast(t,doc)
-  return t
+  tree = massage_ast(tree,doc)
+  return tree
 end
 
 SILE.inputs.TeXlike.order = 99

--- a/core/inputs-xml.lua
+++ b/core/inputs-xml.lua
@@ -1,12 +1,11 @@
 SILE.inputs.XML = {
   order = 1,
-  appropriate = function(fn, sniff)
-    return (fn:match("xml$") or sniff:match("<"))
+  appropriate = function(filename, sniff)
+    return (filename:match("xml$") or sniff:match("<"))
   end,
-  process = function (fn)
+  process = function (doc)
     local lom = require("lomwithpos")
-    local fh = io.open(fn)
-    local t, err = lom.parse(fh:read("*all"))
+    local t, err = lom.parse(doc)
     if t == nil then
       error(err)
     end
@@ -15,7 +14,7 @@ SILE.inputs.XML = {
       if not(t.tag == "sile") then
         SU.error("This isn't a SILE document!")
       end
-      SILE.inputs.common.init(fn, t)
+      SILE.inputs.common.init(doc, t)
     end
     SILE.currentCommand = t
     if SILE.Commands[t.tag] then

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -151,7 +151,7 @@ function SILE.readFile(filename)
   SILE.currentlyProcessingFile = filename
   local doc = nil
   if filename == "-" then
-    io.write("<STDIN>\n")
+    io.stderr:write("<STDIN>\n")
     doc = io.stdin:read("*a")
   else
     filename = SILE.resolveFile(filename)
@@ -167,7 +167,7 @@ function SILE.readFile(filename)
       print("Could not open "..filename..": "..err)
       return
     end
-    io.write("<"..filename..">\n")
+    io.stderr:write("<"..filename..">\n")
     doc = file:read("*a")
   end
   local sniff = doc:sub(1, 100) or ""

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -149,21 +149,27 @@ end
 
 function SILE.readFile(filename)
   SILE.currentlyProcessingFile = filename
-  filename = SILE.resolveFile(filename)
-  if not filename then
-    SU.error("Could not find file")
+  local doc = nil
+  if filename == "-" then
+    io.write("<STDIN>\n")
+    doc = io.stdin:read("*a")
+  else
+    filename = SILE.resolveFile(filename)
+    if not filename then
+      SU.error("Could not find file")
+    end
+    local mode = lfs.attributes(filename).mode
+    if mode ~= "file" and mode ~= "named pipe" then
+      SU.error(filename.." isn't a file or named pipe, it's a ".. mode .."!")
+    end
+    local file, err = io.open(filename)
+    if not file then
+      print("Could not open "..filename..": "..err)
+      return
+    end
+    io.write("<"..filename..">\n")
+    doc = file:read("*a")
   end
-  local mode = lfs.attributes(filename).mode
-  if mode ~= "file" and mode ~= "named pipe" then
-    SU.error(filename.." isn't a file or named pipe, it's a ".. mode .."!")
-  end
-  local file, err = io.open(filename)
-  if not file then
-    print("Could not open "..filename..": "..err)
-    return
-  end
-  io.write("<"..filename..">\n")
-  local doc = file:read("*all")
   local sniff = doc:sub(1, 100) or ""
   local inputsOrder = {}
   for n in pairs(SILE.inputs) do

--- a/core/typesetter.lua
+++ b/core/typesetter.lua
@@ -126,7 +126,7 @@ SILE.defaultTypesetter = std.object {
     print("Writing into "..self.frame:toString())
     print("Recent contributions: ")
     for i = 1,#(self.state.nodes) do
-      io.write(self.state.nodes[i].. " ")
+      io.stderr:write(self.state.nodes[i].. " ")
     end
     print("\nVertical list: ")
     for i = 1,#(self.state.outputQueue) do

--- a/examples/osis/osis.xml
+++ b/examples/osis/osis.xml
@@ -18,7 +18,7 @@ SILE.registerCommand("verse", function(options, content)
   local id = options.osisID
   c,v = string.match(id, "(%d+).(%d+)$")
   if not (c == SILE.scratch.chapter) then
-    io.write(" ("..c..") ")
+    io.stderr:write(" ("..c..") ")
     SILE.call("bigskip")
     SILE.Commands["font"]({ weight = 700, size = "15pt"}, { "Chapter ".. c })
     SILE.typesetter:leaveHmode()

--- a/packages/autodoc.lua
+++ b/packages/autodoc.lua
@@ -1,6 +1,6 @@
 SILE.registerCommand("package-documentation", function (o,c)
   local package = SU.required(o, "src", "src for package documentation")
-  io.write("<"..package..">")
+  io.stderr:write("<"..package..">")
   SILE.process(
     SILE.inputs.TeXlike.docToTree(
       require(package).documentation

--- a/packages/folio.lua
+++ b/packages/folio.lua
@@ -14,7 +14,7 @@ return {
   exports = {
     outputFolio = function (this, frame)
       if not frame then frame = "folio" end
-      io.write("[" .. SILE.formatCounter(SILE.scratch.counters.folio) .. "] ")
+      io.stderr:write("[" .. SILE.formatCounter(SILE.scratch.counters.folio) .. "] ")
       if SILE.scratch.counters.folio.off then
         if SILE.scratch.counters.folio.off == 2 then
           SILE.scratch.counters.folio.off = false

--- a/packages/insertions.lua
+++ b/packages/insertions.lua
@@ -224,13 +224,13 @@ end
 local debugInsertion = function(ins, insbox, topBox, target, targetFrame, totalHeight)
   if SU.debugging("insertions") then
     local h = ins.contentHeight + topBox.height + topBox.depth + ins.contentDepth
-    print("[insertions]", "Incoming insertion")
-    print("top box height", topBox.height)
-    print("insertion", ins, ins.height, ins.depth)
-    print("Total incoming height", h)
-    print("Insertions already in this class ", insbox.height, insbox.depth)
-    print("Page target ", target)
-    print(totalHeight.." worth of content on page so far")
+    io.stderr:write("[insertions]", "Incoming insertion")
+    io.stderr:write("top box height", topBox.height)
+    io.stderr:write("insertion", ins, ins.height, ins.depth)
+    io.stderr:write("Total incoming height", h)
+    io.stderr:write("Insertions already in this class ", insbox.height, insbox.depth)
+    io.stderr:write("Page target ", target)
+    io.stderr:write(totalHeight.." worth of content on page so far")
   end
 end
 

--- a/sile.in
+++ b/sile.in
@@ -16,7 +16,7 @@ end
 SILE.init()
 if SILE.masterFilename then
   if SILE.preamble then
-    print("Loading "..SILE.preamble)
+    io.stderr:write("Loading "..SILE.preamble)
     local c = SILE.resolveFile("classes/"..SILE.preamble)
     local f = SILE.resolveFile(SILE.preamble)
     if c then
@@ -41,7 +41,7 @@ if SILE.masterFilename then
     os.exit(1)
   end
   if SILE.preamble then SILE.documentState.documentClass:finish() end
-  io.write("\n")
+  io.stderr:write("\n")
   if SU.debugging("profile") and pcall(function () require("ProFi") end) then
     ProFi:stop()
     ProFi:writeReport( 'sile-profile.txt' )


### PR DESCRIPTION
This resolves my issue with #414 and makes SILE get along a lot better in a *nix environment. You can now use SILE pretty much any way you would use a any standard  POSIX utility to read/write input. This includes acting as part of a pipeline where the document comes from STDIN and the rendered PDF goes to STDOUT. For example you could run

    $ echo "<sile>This is an XML string</sile>" | sile - | lpr

This feeds an XML document string into sile and sends the output straight to the default printer without fussing with intermediate files. This may sound like a party trick, but consider even for this simple trick four commands would have been run:

    $ echo "<sile>This is an XML string</sile>" > doc.xml
    $ sile doc.xml
    $ lpr doc.pdf
    $ rm doc.xml doc.pdf

This quickly gets out of hand when you have a complicated chain of things you want to run either on the input side, the output side, or both.

This works and using "-" as a filename flag to trigger processing STDIN is _relatively_ standard behavior, but personally I would rather see this be the default for when no filename is provided and move the interactive readline interface behind a flag.