### PR TITLE
Add support for CMYK and grayscale colors.

### DIFF
--- a/core/colorparser.lua
+++ b/core/colorparser.lua
@@ -154,25 +154,25 @@ SILE.colorparser = function(col)
     local c = colorsRGB[col]
     return { r = c[1] / 255, g = c[2] / 255, b = c[3] / 255 }
   end
-  local r, g, b =  col:match("#(%x%x)(%x%x)(%x%x)")
+  local r, g, b = col:match("#(%x%x)(%x%x)(%x%x)")
   if r then
-    return { r = tonumber("0x"..r)/255, g = tonumber("0x"..g)/255, b = tonumber("0x"..b)/255,}
+    return { r = tonumber("0x"..r)/255, g = tonumber("0x"..g)/255, b = tonumber("0x"..b)/255 }
   end
-  local r, g, b =  col:match("#(%x)(%x)(%x)")
+  local r, g, b = col:match("#(%x)(%x)(%x)")
   if r then
     return { r = tonumber("0x"..r)/15, g = tonumber("0x"..g)/15, b = tonumber("0x"..b)/15,}
   end
-  local c, m, y, k = col:match("^%s*(%d+%.?%d*)%s+(%d+%.?%d*)%s+(%d+%.?%d*)%s+(%d+%.?%d*)%s*$")
+  local c, m, y, k = col:match("(%d+%.?%d*)%s+(%d+%.?%d*)%s+(%d+%.?%d*)%s+(%d+%.?%d*)")
   if c then
-    return {c = tonumber(c)/255, m = tonumber(m)/255, y = tonumber(y)/255, k = tonumber(k)/255}
+    return { c = tonumber(c)/255, m = tonumber(m)/255, y = tonumber(y)/255, k = tonumber(k)/255 }
   end
-  local r, g, b = col:match("^%s*(%d+%.?%d*)%s+(%d+%.?%d*)%s+(%d+%.?%d*)%s*$")
+  local r, g, b = col:match("(%d+%.?%d*)%s+(%d+%.?%d*)%s+(%d+%.?%d*)")
   if r then
-    return {r = tonumber(r)/255, g = tonumber(g)/255, b = tonumber(b)/255}
+    return { r = tonumber(r)/255, g = tonumber(g)/255, b = tonumber(b)/255 }
   end
-  local l = col:match("^%s*(%d+.?%d*)%s*$")
+  local l = col:match("(%d+.?%d*)")
   if l then
-    return {l = tonumber(l)/255}
+    return { l = tonumber(l)/255 }
   end
-  SU.error("Unparsable color "..col..print(type(col)))
+  SU.error("Unparsable color "..col)
 end

--- a/core/colorparser.lua
+++ b/core/colorparser.lua
@@ -162,5 +162,17 @@ SILE.colorparser = function(col)
   if r then
     return { r = tonumber("0x"..r)/15, g = tonumber("0x"..g)/15, b = tonumber("0x"..b)/15,}
   end
-  SU.error("Unparsable color "..col)
+  local c, m, y, k = col:match("^%s*(%d+%.?%d*)%s+(%d+%.?%d*)%s+(%d+%.?%d*)%s+(%d+%.?%d*)%s*$")
+  if c then
+    return {c = tonumber(c)/255, m = tonumber(m)/255, y = tonumber(y)/255, k = tonumber(k)/255}
+  end
+  local r, g, b = col:match("^%s*(%d+%.?%d*)%s+(%d+%.?%d*)%s+(%d+%.?%d*)%s*$")
+  if r then
+    return {r = tonumber(r)/255, g = tonumber(g)/255, b = tonumber(b)/255}
+  end
+  local l = col:match("^%s*(%d+.?%d*)%s*$")
+  if l then
+    return {l = tonumber(l)/255}
+  end
+  SU.error("Unparsable color "..col..print(type(col)))
 end

--- a/core/libtexpdf-output.lua
+++ b/core/libtexpdf-output.lua
@@ -28,11 +28,21 @@ SILE.outputters.libtexpdf = {
   end,
   setColor = function(self, color)
     ensureInit()
-    pdf.setcolor(color.r, color.g, color.b)
+    if color.r then
+      pdf.setcolor_rgb(color.r, color.g, color.b)end
+    if color.c then
+      pdf.setcolor_cmyk(color.c, color.m, color.y, color.k)end
+    if color.l then
+      pdf.setcolor_gray(color.l)end
   end,
   pushColor = function (self, color)
     ensureInit()
-    pdf.colorpush(color.r, color.g, color.b)
+    if color.r then
+      pdf.colorpush_rgb(color.r, color.g, color.b)end
+    if color.c then
+      pdf.colorpush_cmyk(color.c, color.m, color.y, color.k)end
+    if color.l then
+      pdf.colorpush_gray(color.l)end
   end,
   popColor = function (self)
     ensureInit()

--- a/core/libtexpdf-output.lua
+++ b/core/libtexpdf-output.lua
@@ -28,21 +28,15 @@ SILE.outputters.libtexpdf = {
   end,
   setColor = function(self, color)
     ensureInit()
-    if color.r then
-      pdf.setcolor_rgb(color.r, color.g, color.b)end
-    if color.c then
-      pdf.setcolor_cmyk(color.c, color.m, color.y, color.k)end
-    if color.l then
-      pdf.setcolor_gray(color.l)end
+    if color.r then pdf.setcolor_rgb(color.r, color.g, color.b) end
+    if color.c then pdf.setcolor_cmyk(color.c, color.m, color.y, color.k) end
+    if color.l then pdf.setcolor_gray(color.l) end
   end,
   pushColor = function (self, color)
     ensureInit()
-    if color.r then
-      pdf.colorpush_rgb(color.r, color.g, color.b)end
-    if color.c then
-      pdf.colorpush_cmyk(color.c, color.m, color.y, color.k)end
-    if color.l then
-      pdf.colorpush_gray(color.l)end
+    if color.r then pdf.colorpush_rgb(color.r, color.g, color.b) end
+    if color.c then pdf.colorpush_cmyk(color.c, color.m, color.y, color.k) end
+    if color.l then pdf.colorpush_gray(color.l) end
   end,
   popColor = function (self)
     ensureInit()

--- a/src/justenoughlibtexpdf.c
+++ b/src/justenoughlibtexpdf.c
@@ -140,25 +140,67 @@ int pdf_setrule(lua_State *L) {
 
 /* Colors */
 
-int pdf_setcolor(lua_State *L) {
+int pdf_colorpush_rgb(lua_State *L) {
   double r = luaL_checknumber(L, 1);
   double g = luaL_checknumber(L, 2);
   double b = luaL_checknumber(L, 3);
 
   pdf_color color;
-  texpdf_color_rgbcolor(&color,r,g,b);
+  texpdf_color_rgbcolor(&color, r, g, b);
+  texpdf_color_push(p, &color, &color);
+  return 0;
+    }
+
+int pdf_colorpush_cmyk(lua_State *L) {
+  double c = luaL_checknumber(L, 1);
+  double m = luaL_checknumber(L, 2);
+  double y = luaL_checknumber(L, 3);
+  double k = luaL_checknumber(L, 4);
+
+  pdf_color color;
+  texpdf_color_cmykcolor(&color, c, m, y, k);
+  texpdf_color_push(p, &color, &color);
+  return 0;
+    }
+
+int pdf_colorpush_gray(lua_State *L) {
+  double l = luaL_checknumber(L, 1);
+
+  pdf_color color;
+  texpdf_color_graycolor(&color, l);
+  texpdf_color_push(p, &color, &color);
+  return 0;
+    }
+
+int pdf_setcolor_rgb(lua_State *L) {
+  double r = luaL_checknumber(L, 1);
+  double g = luaL_checknumber(L, 2);
+  double b = luaL_checknumber(L, 3);
+
+  pdf_color color;
+  texpdf_color_rgbcolor(&color, r, g, b);
   texpdf_color_set(p, &color, &color);
   return 0;
 }
 
-int pdf_colorpush(lua_State *L) {
-  double r = luaL_checknumber(L, 1);
-  double g = luaL_checknumber(L, 2);
-  double b = luaL_checknumber(L, 3);
+int pdf_setcolor_cmyk(lua_State *L) {
+  double c = luaL_checknumber(L, 1);
+  double m = luaL_checknumber(L, 2);
+  double y = luaL_checknumber(L, 3);
+  double k = luaL_checknumber(L, 4);
+  
+  pdf_color color;
+  texpdf_color_cmykcolor(&color, c, m, y, k);
+  texpdf_color_set(p, &color, &color);
+  return 0;
+}
+
+int pdf_setcolor_gray(lua_State *L) {
+  double l = luaL_checknumber(L, 1);
 
   pdf_color color;
-  texpdf_color_rgbcolor(&color,r,g,b);
-  texpdf_color_push(p, &color, &color);
+  texpdf_color_graycolor(&color, l);
+  texpdf_color_set(p, &color, &color);
   return 0;
 }
 
@@ -448,11 +490,15 @@ static const struct luaL_Reg lib_table [] = {
   {"setdirmode", pdf_setdirmode},
   {"setstring", pdf_setstring},
   {"setrule", pdf_setrule},
-  {"setcolor", pdf_setcolor},
+  {"setcolor_rgb", pdf_setcolor_rgb},
+  {"setcolor_cmyk", pdf_setcolor_cmyk},
+  {"setcolor_gray", pdf_setcolor_gray},
   {"drawimage", pdf_drawimage},
   {"imagebbox", pdf_imagebbox},
   {"colorpop", pdf_colorpop},
-  {"colorpush", pdf_colorpush},
+  {"colorpush_rgb", pdf_colorpush_rgb},
+  {"colorpush_cmyk", pdf_colorpush_cmyk},
+  {"colorpush_gray", pdf_colorpush_gray},
   {"setmatrix", pdf_transform},
   {"gsave", pdf_gsave},
   {"grestore", pdf_grestore},


### PR DESCRIPTION
Hi!
As said in #444, I tried to implement cmyk and grayscale colors in SILE.
Everything seems to work as you can see in this quick example: [colors.pdf](https://github.com/simoncozens/sile/files/785048/colors.pdf).
Might not be the best implementation as I'm a newbie in lua  but it doesn't break anything either, which is nice, I think.
So now, you can set colors as you used to but you can also specify each channel's value separated by a space (between 0 and 255, decimals separated by a comma `125.65`).

`colorparser` will then choose which type of color it is depending of the number of channels: 
`\color[color = 125]{1 for grayscale}`
`\color[color=0 0 255]{3 for rgb}`
`\color[color=255 255 0 0]{4 for cmyk}`

Should help a lot to use cmyk colors when printing pdfs even if ICC profiles are still needed for consistent colors.

Have a nice day.