### PR TITLE
Update libtexpdf-output.lua

### DIFF
--- a/core/libtexpdf-output.lua
+++ b/core/libtexpdf-output.lua
@@ -110,7 +110,7 @@ SILE.outputters.libtexpdf = {
   end,
   debugFrame = function (self,f)
     ensureInit()
-    pdf.colorpush(0.8,0,0)
+    pdf.colorpush_rgb(0.8, 0, 0)
     self.rule(f:left(), f:top(), f:width(), 0.5)
     self.rule(f:left(), f:top(), 0.5, f:height())
     self.rule(f:right(), f:top(), 0.5, f:height())


### PR DESCRIPTION
Replaced `pdf.colorpush` with `pdf.colorpush_rgb` (`pdf.colorpush` was removed from `src/justenoughlibtexpdf.c` in f0deadb).

This allows `fold_unless_fail 'Compiled documents' 'compile_docs' ./tests/attack.pl` to exit successfully in Travis CI builds.