### PR TITLE
Process multiple instances of command line options

### DIFF
--- a/core/sile.lua
+++ b/core/sile.lua
@@ -38,7 +38,7 @@ SILE.linebreak = require("core/break")
 
 require("core/frame")
 
-SILE.init = function()
+SILE.init = function ()
   if not SILE.backend then
     if pcall(function () require("justenoughharfbuzz") end) then
       SILE.backend = "libtexpdf"
@@ -51,8 +51,10 @@ SILE.init = function()
     require("core/libtexpdf-output")
   end
   if SILE.dolua then
-    _, err = pcall(SILE.dolua)
-    if err then error(err) end
+    for _, func in pairs(SILE.dolua) do
+      _, err = pcall(func)
+      if err then error(err) end
+    end
   end
 end
 
@@ -102,8 +104,13 @@ Options:
     for k,v in ipairs(std.string.split(opts.debug, ",")) do SILE.debugFlags[v] = 1 end
   end
   if opts.evaluate then
-    SILE.dolua,err = loadstring(opts.evaluate)
-    if err then SU.error(err) end
+    local statements = type(opts.evaluate) == "table" and opts.evaluate or { opts.evaluate }
+    SILE.dolua = {}
+    for _, statement in ipairs(statements) do
+      local func, err = loadstring(statement)
+      if err then SU.error(err) end
+      SILE.dolua[#SILE.dolua+1] = func
+    end
   end
   if opts.output then
     SILE.outputFilename = opts.output

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -109,7 +109,7 @@ Options:
     SILE.outputFilename = opts.output
   end
   if opts.include then
-    SILE.preamble = opts.include
+    SILE.preamble = type(opts.include) == "table" and opts.include or { opts.include }
   end
 end
 

--- a/sile.in
+++ b/sile.in
@@ -16,15 +16,17 @@ end
 SILE.init()
 if SILE.masterFilename then
   if SILE.preamble then
-    io.stderr:write("Loading "..SILE.preamble)
-    local c = SILE.resolveFile("classes/"..SILE.preamble)
-    local f = SILE.resolveFile(SILE.preamble)
-    if c then
-      SILE.readFile(c)
-    elseif f then
-      SILE.readFile(f)
-    else
-      SILE.require("classes/"..SILE.preamble)
+    for _, preamble in pairs(SILE.preamble) do
+      io.stderr:write("Loading "..preamble)
+      local c = SILE.resolveFile("classes/"..preamble)
+      local f = SILE.resolveFile(preamble)
+      if c then
+        SILE.readFile(c)
+      elseif f then
+        SILE.readFile(f)
+      else
+        SILE.require("classes/"..preamble)
+      end
     end
   end
   if SU.debugging("profile") and pcall(function () require("ProFi") end) then


### PR DESCRIPTION
This should fix #443 by allowing multiple instances of `-I` and `-e` flags from the command line.