### PR TITLE
readme: fix showoff.pdf link

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ SILE is distributed under the [MIT licence][license].
   [github]: https://github.com/simoncozens/sile
   [license]: http://choosealicense.com/licenses/mit/
   [faq]: https://github.com/simoncozens/sile/wiki/faq
-  [showoff]: https://raw.githubusercontent.com/simoncozens/sile/master/examples/showoff.pdf
+  [showoff]: https://rawgit.com/simoncozens/sile/b66b979a6dca0c60bd4aa2cbad3da36ae2073672/examples/showoff.pdf
   [roadmap]: https://github.com/simoncozens/sile/blob/master/ROADMAP
   [luarocks]: http://luarocks.org/en/Download
   [harfbuzz]: http://www.freedesktop.org/wiki/Software/HarfBuzz/


### PR DESCRIPTION
It was removed from the repo, I linked up the last time it was in there.
Also using rawgit otherwise github will force a download.
