### PR TITLE
Fix includes of TeX-flavor content

### DIFF
--- a/core/inputs-texlike.lua
+++ b/core/inputs-texlike.lua
@@ -142,14 +142,14 @@ end
 function SILE.inputs.TeXlike.process (doc)
   local tree = SILE.inputs.TeXlike.docToTree(doc)
   local root = SILE.documentState.documentClass == nil
-  if root then
-    if tree.tag == "document" then
+  if tree.tag then
+    if root and tree.tag == "document" then
       SILE.inputs.common.init(doc, tree)
-      SILE.process(tree)
-    elseif pcall(function () assert(loadstring(doc))() end) then
-    else
-      SU.error("Input not recognized as Lua or SILE content")
     end
+    SILE.process(tree)
+  elseif pcall(function () assert(loadstring(doc))() end) then
+  else
+    SU.error("Input not recognized as Lua or SILE content")
   end
   if root and not SILE.preamble then
     SILE.documentState.documentClass:finish()

--- a/packages/bibtex.lua
+++ b/packages/bibtex.lua
@@ -62,7 +62,7 @@ SILE.registerCommand("cite", function(o,c)
     SU.warn("Unknown reference in citation "..o)
     return
   end
-  SILE.process(SILE.inputs.TeXlike.docToTree("\\begin{document}"..cite.."\\end{document}"))
+  SILE.doTexlike(cite)
 end)
 
 SILE.registerCommand("reference", function(o,c)
@@ -72,5 +72,5 @@ SILE.registerCommand("reference", function(o,c)
     SU.warn("Unknown reference in citation "..o)
     return
   end
-  SILE.process(SILE.inputs.TeXlike.docToTree("\\begin{document}"..cite.."\\end{document}"))
+  SILE.doTexlike(cite)
 end)

--- a/tests/bug-465-a.expected
+++ b/tests/bug-465-a.expected
@@ -1,0 +1,15 @@
+Set paper size 	419.5275636	595.275597
+Begin page
+Mx 	40.9764
+My 	37.3321
+Set font 	Gentium Plus;10;400;;normal;;LTR
+T	43 72 79 79 82	(Hello)
+Mx 	65.2592
+T	90 82 85 79 71	(world)
+Mx 	89.2192
+T	17	(.)
+Mx 	207.4176
+My 	553.7327
+T	20	(1)
+End page
+Finish

--- a/tests/bug-465-b.sil
+++ b/tests/bug-465-b.sil
@@ -1,3 +1,3 @@
-\begin[papersize=a5]{document}
-world
+\begin[papersize=a5]{document}%
+world%
 \end{document}


### PR DESCRIPTION
This should fix the issue with included TeX-flavor markup being silently dropped.

- [x] Whip up something that fixes #465 ~~~(and #505 which is essentially the same but subtly different in that the include does not have its own document tag).~~~
- [x] ...while not breaking #414.