### PR TITLE
Add a hbox debugging tool

### DIFF
--- a/classes/plain.lua
+++ b/classes/plain.lua
@@ -186,6 +186,7 @@ SILE.registerCommand("hbox", function (options, content)
       if typesetter.frame:writingDirection() ~= "RTL" then
         typesetter.frame:advanceWritingDirection(self:scaledWidth(line))
       end
+      if SU.debugging("hboxes") then SILE.outputter.debugHbox(self, self:scaledWidth(line)) end
     end
   })
   table.insert(SILE.typesetter.state.nodes, hbox)

--- a/core/libtexpdf-output.lua
+++ b/core/libtexpdf-output.lua
@@ -129,7 +129,20 @@ SILE.outputters.libtexpdf = {
     pdf.setstring(f:left(), SILE.documentState.paperSize[2] -f:top(), buf, string.len(buf), font, 0)
     pdf.colorpop()
   end,
-  debugHbox = function(typesetter, hbox, scaledWidth)
+  debugHbox = function(hbox, scaledWidth)
+    ensureInit()
+    pdf.colorpush_rgb(0.8, 0.3, 0.3)
+    pdf.setrule(cursorX,cursorY+(hbox.height), scaledWidth+0.5, 0.5)
+    pdf.setrule(cursorX,cursorY, 0.5, hbox.height)
+    pdf.setrule(cursorX, cursorY, scaledWidth+0.5, 0.5)
+    pdf.setrule(cursorX+scaledWidth,cursorY, 0.5, hbox.height)
+    if hbox.depth then
+      pdf.setrule(cursorX,cursorY-(hbox.depth), scaledWidth, 0.5)
+      pdf.setrule(cursorX+scaledWidth,cursorY-(hbox.depth), 0.5, hbox.depth)
+      pdf.setrule(cursorX,cursorY-(hbox.depth), 0.5, hbox.depth)
+
+    end
+    pdf.colorpop()
   end
 }
 


### PR DESCRIPTION
Fixes #515

Use it like this in your hbox’s output routine:

    SILE.outputter.debugHbox(self, self:scaledWidth(line))