### PR TITLE
Setup paths so different checkouts can be debugged in parallel

### DIFF
--- a/sile.in
+++ b/sile.in
@@ -13,6 +13,11 @@ local pathvar = os.getenv("SILE_PATH")
 if pathvar then
 	for path in string.gmatch(pathvar, "[^;]+") do
 		package.path =  path .. "/?.lua;" .. package.path
+		package.path =  path .. "/?/init.lua;" .. package.path
+		package.path =  path .. "/lua-libraries/?.lua;" .. package.path
+		package.path =  path .. "/lua-libraries/?/init.lua;" .. package.path
+		package.cpath = path .. "/?."..SHARED_LIB_EXT..";" .. package.cpath
+		package.cpath = path .. "/core/?."..SHARED_LIB_EXT..";" .. package.cpath
 	end
 end
 


### PR DESCRIPTION
Without this it is easy to debug SILE running tests from _inside_ the SILE path (because the current working directory is searched first by default) but it is very hard to use a version of SILE located in a directory somewhere on the system from some other path. In my case I'm trying to test different versions of SILE on book projects and need to run `sile` from my project's directory. This sets up the search paths in such a way that I can `export SILE_PATH` and have it search that for modules and packages before using the system installation path.