### PR TITLE
Hansel and Gretel

### DIFF
--- a/core/baseclass.lua
+++ b/core/baseclass.lua
@@ -1,7 +1,7 @@
 SILE.Help = {}
 
 SILE.registerCommand = function (name, func, help, pack)
-  SILE.Commands[name] = func
+  SILE.Commands[name] = SU.breadcrumbs(name, func)
   if not pack then
     local where = debug.getinfo(2).source
     pack = where:match("(%w+).lua")

--- a/core/baseclass.lua
+++ b/core/baseclass.lua
@@ -1,7 +1,11 @@
 SILE.Help = {}
 
 SILE.registerCommand = function (name, func, help, pack)
-  SILE.Commands[name] = SU.breadcrumbs(name, func)
+  if SILE.typesetter and SILE.typesetter.breadcrumbs then
+    SILE.Commands[name] = SILE.typesetter.breadcrumbs(name, func)
+  else
+    SILE.Commands[name] = func
+  end
   if not pack then
     local where = debug.getinfo(2).source
     pack = where:match("(%w+).lua")

--- a/core/baseclass.lua
+++ b/core/baseclass.lua
@@ -1,11 +1,7 @@
 SILE.Help = {}
 
 SILE.registerCommand = function (name, func, help, pack)
-  if SILE.typesetter and SILE.typesetter.breadcrumbs then
-    SILE.Commands[name] = SILE.typesetter.breadcrumbs(name, func)
-  else
-    SILE.Commands[name] = func
-  end
+  SILE.Commands[name] = SILE.typesetter and SILE.typesetter.breadcrumbs(name, func) or func
   if not pack then
     local where = debug.getinfo(2).source
     pack = where:match("(%w+).lua")

--- a/core/typesetter.lua
+++ b/core/typesetter.lua
@@ -82,6 +82,7 @@ local _margins = std.object {
 SILE.defaultTypesetter = std.object {
   -- Setup functions
   hooks = {},
+  breadcrumbs = SU.breadcrumbs(),
   init = function(self, frame)
     self.stateQueue = {}
     self:initFrame(frame)

--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -406,4 +406,17 @@ setmetatable (utilities.breadcrumbs, {
       end
   })
 
+function utilities.breadcrumbs:dump ()
+  SU.dump(self)
+end
+
+function utilities.breadcrumbs:parent (n)
+  return self[#self-(n or 1)]
+end
+
+function utilities.breadcrumbs:contains (cmd)
+  for i, name in ipairs(self) do if name == cmd then return #self-i end end
+  return 0
+end
+
 return utilities

--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -385,4 +385,25 @@ utilities.utf8_to_utf16le = function (str)
   return ustr
 end
 
+utilities.breadcrumbs = { "document" }
+
+setmetatable (utilities.breadcrumbs, {
+    __call = function (self, name, func)
+        return function (...)
+            if name ~= "define" then
+              self[#self+1] = name
+              SU.debug("breadcrumbs", "Enter command " .. name)
+            end
+            func(...)
+            if name ~= "define" then
+              self[#self] = nil
+              SU.debug("breadcrumbs", "Leave command " .. name)
+            end
+          end
+      end,
+    __tostring = function (self)
+        return "B»" .. table.concat(self, "»")
+      end
+  })
+
 return utilities

--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -385,38 +385,43 @@ utilities.utf8_to_utf16le = function (str)
   return ustr
 end
 
-utilities.breadcrumbs = { "document" }
+utilities.breadcrumbs = function ()
+  local breadcrumbs = { "document" }
 
-setmetatable (utilities.breadcrumbs, {
-    __call = function (self, name, func)
-        return function (...)
-            if name ~= "define" then
-              self[#self+1] = name
-              SU.debug("breadcrumbs", "Enter command " .. name)
+  setmetatable (breadcrumbs, {
+      __call = function (self, name, func)
+          return function (...)
+              if name ~= "define" then
+                self[#self+1] = name
+                SU.debug("breadcrumbs", "Enter command " .. name)
+              end
+              local ret = func(...)
+              if name ~= "define" and self then
+                self[#self] = nil
+                SU.debug("breadcrumbs", "Leave command " .. name)
+              end
+              return ret
             end
-            func(...)
-            if name ~= "define" then
-              self[#self] = nil
-              SU.debug("breadcrumbs", "Leave command " .. name)
-            end
-          end
-      end,
-    __tostring = function (self)
-        return "B»" .. table.concat(self, "»")
-      end
-  })
+        end,
+      __tostring = function (self)
+          return "B»" .. table.concat(self, "»")
+        end
+    })
 
-function utilities.breadcrumbs:dump ()
-  SU.dump(self)
-end
+  function breadcrumbs:dump ()
+    SU.dump(self)
+  end
 
-function utilities.breadcrumbs:parent (n)
-  return self[#self-(n or 1)]
-end
+  function breadcrumbs:parent (n)
+    return self[#self-(n or 1)]
+  end
 
-function utilities.breadcrumbs:contains (cmd)
-  for i, name in ipairs(self) do if name == cmd then return #self-i end end
-  return 0
+  function breadcrumbs:contains (cmd)
+    for i, name in ipairs(self) do if name == cmd then return #self-i end end
+    return -1
+  end
+
+  return breadcrumbs
 end
 
 return utilities


### PR DESCRIPTION
A while ago in #312 I asked about detecting the context a command was executed from. I've experimented with several ways of doing this and this is the most useful one I've come up with so far. Overloading `SILE.process()` tends to turn up far too much noise to be useful. This hijacks the `SILE.registerCommand()` function and creates functions that are wrappers that push and pop their own names off a stack of command names.

I was going to put this tracking behind a flag on some sort, but I did some profiling on an old slow machine compiling the manual and came up with 80.82 seconds with the original sile version and 81.04 with the breadcrumb tracker. In other words the difference is not appreciable. In fact to even come up with the difference that direction I had to run both versions several times. The difference is system noise.

This enables some useful things like getting a list of all the commands in the current stack (i.e. all the open nested function contexts). There is a `dump()` function for quick and dirty debugging, you can turn on `sile -d breadcrumbs` to see every entry and exit as it happens, but perhaps most interestingly you can have a look at the context directly by looking at the name of the `parent()` function (or nth parent `parent(2)`) or query if there are any parents with a given name with `contains(name)`.

```lua
SILE.typesetter.breadcrumbs:dump()
local grandparent = SILE.typesetter.breadcrumbs:parent(2)
local in_ragged = SILE.typesetter.breadcrumbs:contains("ragged")
```

Note due to a race condition where the baseclass is fired up before a typesetter exists, this does not track `define()`, `process()`, or `comment()` — but the noise these produce suggests that might be a good thing anyway.