### PR TITLE
fixes #556 : uninitialed pdf in function pdf:destination

### DIFF
--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -11,6 +11,7 @@ SILE.registerCommand("pdf:destination", function (options, content)
     width = 0,
     depth = 0,
     outputYourself = function (self, typesetter)
+      SILE.outputters.libtexpdf._init()
       pdf.destination(name, typesetter.frame.state.cursorX, SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY)
     end
   })

--- a/tests/bug-556b.sil
+++ b/tests/bug-556b.sil
@@ -1,0 +1,6 @@
+\begin[class=triglot]{document}
+\script[src=packages/pdf]
+\left
+\pdf:destination[name=test]
+\sync
+\end{document}


### PR DESCRIPTION
As mentioned in #556 this PR fixes uninitialized pdf in case of command pdf:destination 