### PR TITLE
Change default font weight

### DIFF
--- a/core/font.lua
+++ b/core/font.lua
@@ -52,7 +52,7 @@
 
 SILE.settings.declare({name = "font.family", type = "string", default = "Gentium Plus"})
 SILE.settings.declare({name = "font.size", type = "number or integer", default = 10})
-SILE.settings.declare({name = "font.weight", type = "integer", default = 400})
+SILE.settings.declare({name = "font.weight", type = "integer", default = 80})
 SILE.settings.declare({name = "font.variant", type = "string", default = "normal"})
 SILE.settings.declare({name = "font.script", type = "string", default = ""})
 SILE.settings.declare({name = "font.style", type = "string", default = ""})


### PR DESCRIPTION
400 is not a good default value for font weight. According to [fontconfig source](https://gitlab.freedesktop.org/fontconfig/fontconfig/blob/master/fontconfig/fontconfig.h#L147), the weight for regular font should be 80.