### PR TITLE
Mask font index from fontconfig to lower 16-bit

### DIFF
--- a/core/harfbuzz-shaper.lua
+++ b/core/harfbuzz-shaper.lua
@@ -1,6 +1,7 @@
 
 if not SILE.shapers then SILE.shapers = { } end
 local hb = require("justenoughharfbuzz")
+local bit32 = require("bit32-compat")
 
 SILE.settings.declare({
   name = "harfbuzz.subshapers",
@@ -61,6 +62,10 @@ SILE.shapers.harfbuzz = SILE.shapers.base {
     local face = fontconfig._face(opts)
     SU.debug("fonts", "Resolved font family "..opts.family.." -> "..(face and face.filename))
     if not face.filename then SU.error("Couldn't find face "..opts.family) end
+    if bit32.rshift(face.index, 16) ~= 0 then
+      SU.warn("GX feature in "..opts.family.." is not supported, fallback to regular font face.")
+      face.index = bit32.band(face.index, 0xff)
+    end
     local fh,e = io.open(face.filename, "rb")
     if e then SU.error("Can't open "..face.filename..": "..e) end
     face.data = fh:read("*all")

--- a/src/justenoughfontconfig.c
+++ b/src/justenoughfontconfig.c
@@ -113,9 +113,6 @@ int face_from_options(lua_State* L) {
     return 0;
   
   FcPatternGetInteger(matched, FC_INDEX, 0, &index);
-#if FC_VERSION >= 21195
-  index &= 0xFFFF;
-#endif
   font_path = (FcChar8 *)strdup((char*)font_path);
   if (!font_path) {
     printf("Finding font path failed\n");

--- a/src/justenoughfontconfig.c
+++ b/src/justenoughfontconfig.c
@@ -113,6 +113,9 @@ int face_from_options(lua_State* L) {
     return 0;
   
   FcPatternGetInteger(matched, FC_INDEX, 0, &index);
+#if FC_VERSION >= 21195
+  index &= 0xFFFF;
+#endif
   font_path = (FcChar8 *)strdup((char*)font_path);
   if (!font_path) {
     printf("Finding font path failed\n");


### PR DESCRIPTION
Since fontconfig 2.11.95, fontconfig [introduced TrueType GX support](https://github.com/freedesktop/fontconfig/commit/27d61f1ddcda5543e9c6440a0f8794caa0b1eac7), which changes the meaning of `index` property in fontconfig. The field is originally used for specifying the index of the font face in a font file which contains multiple font faces. However, since 2.11.95, fontconfig start to use its higher 16-bit to hold the number of named instances available for the current face if we have a GX or OpenType variation (sub)font (which is quite similar to the [style_flags](https://github.com/aseprite/freetype2/blob/master/include/freetype/freetype.h#L905) option in freetype). However, libtexpdf does not support GX and `index` is only treated as the font face index. When font with GX feature is rendered, libtexpdf could crash because SILE passes a very large font face index to it (when the high 16 bits of variation instance is non-zero). To handle the crashing in SILE, considering libtexpdf does not support GX yet, the only reasonable thing left to us is masking the low 16 bits of fontconfig `index` property.