### PR TITLE
Allow setting PDF metadata with \pdf:metadata

### DIFF
--- a/documentation/sile.sil
+++ b/documentation/sile.sil
@@ -23,6 +23,8 @@
 \par\center{\font[size=50pt,weight=600,filename=documentation/Silson-Condensed.otf]{The}\par
 \center{\img[src=documentation/sile-logo.pdf,height=40mm]}\par
 \font[size=50pt,weight=600,filename=documentation/Silson-Condensed.otf]{Book}}
+\pdf:metadata[key=Title, val=The SILE book]
+\pdf:metadata[key=Author, val=Simon Cozens]
 \bigskip
 \font[size=12pt,filename=documentation/Silson-Condensed.otf]{\hss for SILE version \sileversion \hss \par}
 \skip[height=1in]

--- a/documentation/sile.sil
+++ b/documentation/sile.sil
@@ -23,7 +23,7 @@
 \par\center{\font[size=50pt,weight=600,filename=documentation/Silson-Condensed.otf]{The}\par
 \center{\img[src=documentation/sile-logo.pdf,height=40mm]}\par
 \font[size=50pt,weight=600,filename=documentation/Silson-Condensed.otf]{Book}}
-\pdf:metadata[key=Title, val=The SILE book]
+\pdf:metadata[key=Title, val=The SILE Book]
 \pdf:metadata[key=Author, val=Simon Cozens]
 \bigskip
 \font[size=12pt,filename=documentation/Silson-Condensed.otf]{\hss for SILE version \sileversion \hss \par}

--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -89,14 +89,32 @@ SILE.registerCommand("pdf:link", function (options, content)
   })
 end)
 
+SILE.registerCommand("pdf:metadata", function (options, content)
+  local key = SU.required(options, "key", "pdf:metadata")
+  local val = SU.required(options, "val", "pdf:metadata")
+  SILE.typesetter:pushHbox({
+    value = nil,
+    height = 0,
+    width = 0,
+    depth = 0,
+    outputYourself = function (self,typesetter)
+      SILE.outputter._init()
+      pdf.metadata(key, val)
+    end
+  })
+end)
+
 return { documentation = [[\begin{document}
 The \code{pdf} package enables (basic) support for PDF links and table-of-contents
-entries. It provides the three commands \command{\\pdf:destination}, \command{\\pdf:link}
-and \command{\\pdf:bookmark}.
+entries. It provides the four commands \command{\\pdf:destination}, \command{\\pdf:link},
+\command{\\pdf:bookmark}, and \command{\\pdf:metadata}.
 
 The \command{\\pdf:destination} parameter creates a link target; it expects a
 parameter called \code{name} to uniquely identify the target. To create a link to
 that location in the document, use \code{\\pdf:link[dest=\goodbreak{}name]\{link content\}}.
+
+To set arbitrary key-value metadata, use something like \code{\\pdf:metadata[key=Author,
+value=J. Smith]}. Recall that the PDF metadata field names are case-sensitive.
 
 If the \code{pdf} package is loaded after the \code{tableofcontents} package (e.g.
 in a document with the \code{book} class), then a PDF document outline will be generated.

--- a/packages/pdf.lua
+++ b/packages/pdf.lua
@@ -114,7 +114,9 @@ parameter called \code{name} to uniquely identify the target. To create a link t
 that location in the document, use \code{\\pdf:link[dest=\goodbreak{}name]\{link content\}}.
 
 To set arbitrary key-value metadata, use something like \code{\\pdf:metadata[key=Author,
-value=J. Smith]}. Recall that the PDF metadata field names are case-sensitive.
+value=J. Smith]}. The PDF metadata field names are case-sensitive. Common keys include
+\code{Title}, \code{Author}, \code{Subject}, \code{Keywords}, \code{CreationDate}, and
+\code{ModDate}.
 
 If the \code{pdf} package is loaded after the \code{tableofcontents} package (e.g.
 in a document with the \code{book} class), then a PDF document outline will be generated.

--- a/src/justenoughlibtexpdf.c
+++ b/src/justenoughlibtexpdf.c
@@ -294,6 +294,17 @@ int pdf_end_annotation(lua_State *L) {
   texpdf_release_obj(dict);
   return 0;
 }
+
+int pdf_metadata(lua_State *L) {
+  const char* key = luaL_checkstring(L, 1);
+  const char* val = luaL_checkstring(L, 2);
+  ASSERT(p);
+  ASSERT(key);
+  ASSERT(val);
+  texpdf_add_dict(p->info,
+               texpdf_new_name(key),
+               texpdf_new_string(val, strlen(val)));
+}
 /* Images */
 
 int pdf_drawimage(lua_State *L) {
@@ -524,6 +535,7 @@ static const struct luaL_Reg lib_table [] = {
   {"bookmark", pdf_bookmark},
   {"begin_annotation", pdf_begin_annotation},
   {"end_annotation", pdf_end_annotation},
+  {"metadata", pdf_metadata},
   {"version", pdf_version},
   {"add_content", pdf_add_content},
   {"get_dictionary", pdf_get_dictionary},


### PR DESCRIPTION
I often find myself organizing PDFs by metadata. LaTeX's
`\usepackage[pdfusetitle]{hyperref}` is useful for that, so here's my
attempt at adding an equivalent to `packages/pdf`. (For verification,
I usually use `exiftool` or the stricter `pdfinfo`.)

It doesn't appear that PDF-specific details can be tested at present,
so there's no test file, but hopefully documentation/sile.sil will serve
as an example.

As before, please feel free to reject, rewrite, or take some parts.
