### PR TITLE
Add instruction to run `ldconfig` after install

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ Once your dependencies are installed, run:
     $ ./configure
     $ make install
 
-This will place the SILE libraries and executable in a sensible location.
+This will place the SILE libraries and executable in a sensible location. You may also need to run:
+
+    $ sudo ldconfig
+
+… before trying to execute `sile` to make the system aware of the newly installed libraries.
 
 ### Default font
 


### PR DESCRIPTION
Some systems need `ldconfig` to be run to be formally informed of newly installed libraries. Hence it would be useful to advise users of this when trying to install/use by compiling from source.

Fixes #554.