### PR TITLE
Normalize set() functions

### DIFF
--- a/core/settings.lua
+++ b/core/settings.lua
@@ -1,9 +1,3 @@
-local _type = function(v)
-  if type(v) == "number" then return math.floor(v)==v and "integer" or "number" end
-  if not(type(v) == "table") then return type(v) end
-  return v:prototype()
-end
-
 SILE.settings = {
   state = {},
   declarations = {},
@@ -18,8 +12,8 @@ SILE.settings = {
   end,
   declare = function(spec)
     SILE.settings.declarations[spec.name] = spec
-    SILE.settings.set(spec.name, spec.default)
     SILE.settings.defaults[spec.name] = spec.default
+    SILE.settings.set(spec.name)
   end,
   reset = function()
     for k,_ in pairs(SILE.settings.state) do
@@ -30,18 +24,17 @@ SILE.settings = {
     if not SILE.settings.declarations[name] then
       SU.error("Undefined setting '"..name.."'")
     end
-    return SILE.settings.state[name]
+    return SILE.settings.state[name] or SILE.settings.defaults[name]
   end,
   set = function(name, value)
     if not SILE.settings.declarations[name] then
       SU.error("Undefined setting '"..name.."'")
     end
-    local valuetype = _type(value)
-    local wantedType = SILE.settings.declarations[name].type
-    if not (string.find(wantedType, valuetype) == 1 or string.find(wantedType, "or "..valuetype) ) then
-      SU.error("Setting "..name.." must be of type "..wantedType..", not "..valuetype.." "..value.."\n"..name..": "..SILE.settings.declarations[name].help)
+    if type(value) == "nil" then
+      SILE.settings.state[name] = nil
+    else
+      SILE.settings.state[name] = SU.cast(SILE.settings.declarations[name].type, value)
     end
-    SILE.settings.state[name] = value
   end,
   temporarily = function(func)
     SILE.settings.pushState()
@@ -57,7 +50,6 @@ SILE.settings = {
       SILE.settings.popState()
     end
   end,
-
 }
 
 SILE.settings.declare({
@@ -117,29 +109,19 @@ local function toboolean(v)
 end
 
 SILE.registerCommand("set", function(options, content)
-  local p = SU.required(options, "parameter", "\\set command")
-  local v = options.value -- could be nil!
-  local def = SILE.settings.declarations[p]
+  local parameter = SU.required(options, "parameter", "\\set command")
   local makedefault = SU.boolean(options.makedefault, false)
-  if not def then SU.error("Unknown parameter "..p.." in \\set command") end
-  if     string.match(def.type, "nil") and type(v) == "nil" then -- ok
-  elseif  string.match(def.type, "integer") then v = tonumber(v)
-  elseif  string.match(def.type, "number") then v = tonumber(v)
-  elseif  string.match(def.type, "boolean") then v = toboolean(v)
-  elseif  string.match(def.type, "Length") then v = SILE.length.parse(v)
-  elseif string.match(def.type, "VGlue") then v = SILE.nodefactory.newVglue(v)
-  elseif string.match(def.type, "Glue") then v = SILE.nodefactory.newGlue(v)
-  elseif string.match(def.type, "Kern") then v = SILE.nodefactory.newKern(v) end
+  local value = options.value
   if content and (type(content) == "function" or content[1]) then
     SILE.settings.temporarily(function()
-      SILE.settings.set(p,v)
+      SILE.settings.set(parameter, value)
       SILE.process(content)
     end)
   else
-    SILE.settings.set(p,v)
+    SILE.settings.set(parameter, value)
   end
   if makedefault then
-    SILE.settings.declarations[p].default = v
-    SILE.settings.defaults[p] = v
+    SILE.settings.declarations[parameter].default = value
+    SILE.settings.defaults[parameter] = value
   end
 end, "Set a SILE parameter <parameter> to value <value> (restoring the value afterwards if <content> is provided)")

--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -181,6 +181,32 @@ utilities.allCombinations = function (options)
   end)
 end
 
+utilities.type = function(value)
+  if type(value) == "number" then
+    return math.floor(value) == value and "integer" or "number"
+  elseif type(value) == "table" then
+    return value:prototype()
+  else
+    return type(value)
+  end
+end
+
+utilities.cast = function (wantedType, value)
+  local actualType = SU.type(value)
+  if string.match(wantedType, actualType)     then return value
+  elseif actualType == "nil"
+     and string.match(wantedType, "nil")      then return nil
+  elseif string.match(wantedType, "integer")  then return tonumber(value)
+  elseif string.match(wantedType, "number")   then return tonumber(value)
+  elseif string.match(wantedType, "boolean")  then return SU.boolean(value)
+  elseif string.match(wantedType, "Length")   then return SILE.length.parse(value)
+  elseif string.match(wantedType, "VGlue")    then return SILE.nodefactory.newVglue(value)
+  elseif string.match(wantedType, "Glue")     then return SILE.nodefactory.newGlue(value)
+  elseif string.match(wantedType, "Kern")     then return SILE.nodefactory.newKern(value)
+  else SU.warn("Unrecognized type: "..wantedType); return value
+  end
+end
+
 -- Flatten content trees into just the string components (allows passing
 -- objects with complex structures to functions that need plain strings)
 utilities.contentToString = function (content)


### PR DESCRIPTION
Currently `SILE.settings.set()` behaves entirely differently than `SILE.call("set", ...)`. Automatic type casting is being done in the `SILE.call("set")` implementation, but the `SILE.settings.set()` implementation handles it differently. This normalizes the two by doing the casting in the latter and making the former just call the later without doing all its own monkey business.
