### PR TITLE
feat(book): Add option to disable ToC entry for book section

### DIFF
--- a/classes/book.lua
+++ b/classes/book.lua
@@ -94,10 +94,11 @@ SILE.registerCommand("right-running-head", function (options, content)
 end, "Text to appear on the top of the right page")
 
 SILE.registerCommand("book:sectioning", function (options, content)
-  local content = SU.subContent(content)
   local level = SU.required(options, "level", "book:sectioning")
-  SILE.call("increment-multilevel-counter", {id = "sectioning", level = options.level})
-  SILE.call("tocentry", {level = options.level}, content)
+  SILE.call("increment-multilevel-counter", {id = "sectioning", level = level})
+  if SU.boolean(options.toc, true) then
+    SILE.call("tocentry", {level = level}, SU.subContent(content))
+  end
   local lang = SILE.settings.get("document.language")
   if options.numbering == nil or options.numbering == "yes" then
     if options.prenumber then
@@ -136,6 +137,7 @@ SILE.registerCommand("chapter", function (options, content)
   SILE.call("book:chapterfont", {}, function ()
     SILE.call("book:sectioning", {
       numbering = options.numbering,
+      toc = options.toc,
       level = 1,
       prenumber = "book:chapter:pre",
       postnumber = "book:chapter:post"
@@ -160,6 +162,7 @@ SILE.registerCommand("section", function (options, content)
   SILE.call("book:sectionfont", {}, function ()
     SILE.call("book:sectioning", {
       numbering = options.numbering,
+      toc = options.toc,
       level = 2,
       postnumber = "book:section:post"
     }, content)
@@ -191,6 +194,7 @@ SILE.registerCommand("subsection", function (options, content)
   SILE.call("book:subsectionfont", {}, function ()
     SILE.call("book:sectioning", {
           numbering = options.numbering,
+          toc = options.toc,
           level = 3,
           postnumber = "book:subsection:post"
         }, content)


### PR DESCRIPTION
It may sometimes be useful to exclude some sections from table of contents, this adds the ability to do it through: `\subsection[toc=false]{Not in ToC}`.

Another two proposed & related changes:
1. In my fork, I don't increment section counters when `numbering` is `false`. This works quite well in combination with `toc=false`, so I propose adding it. The current behavior could be preserved with `numbering=hidden` (or some variant which preserves backwards compatibility).
2. [Current check for `numbering` in book.lua](https://github.com/simoncozens/sile/blob/master/classes/book.lua#L102), "`if options.numbering == nil or options.numbering == "yes"`", looks like it could benefit from `SU.boolean()`. However, that function does not check for `yes/no`, only for `true/false`. I propose extending `SU.boolean()` with this wider matching (and possibly even more options, `y/n`, `1/0`, ...) and using it there. This change should not lead to any any broken code (at least inside SILE), because all usages of `SU.boolean` parse user input and don't depend on its current strict behavior.