### PR TITLE
counters: Improve external API and cleanup internal code

### DIFF
--- a/packages/counters.lua
+++ b/packages/counters.lua
@@ -63,15 +63,13 @@ SILE.formatCounter = function(counter)
 end
 
 local function getCounter(id)
-  local counter = SILE.scratch.counters[id]
-  if not counter then
-    counter = {}
-    SILE.scratch.counters[id] = { value= 0, display= "arabic", format = SILE.formatCounter }
+  if not SILE.scratch.counters[id] then
+    SILE.scratch.counters[id] = { value = 0, display = "arabic", format = SILE.formatCounter }
   end
-  return counter
+  return SILE.scratch.counters[id]
 end
 
-SILE.registerCommand("increment-counter", function (options, _)
+SILE.registerCommand("increment-counter", function (options, content)
   local counter = getCounter(options.id)
   if (options["set-to"]) then
     counter.value = tonumber(options["set-to"])
@@ -81,14 +79,14 @@ SILE.registerCommand("increment-counter", function (options, _)
   if options.display then counter.display = options.display end
 end, "Increments the counter named by the <id> option")
 
-SILE.registerCommand("set-counter", function (options, _)
+SILE.registerCommand("set-counter", function (options, content)
   local counter = getCounter(options.id)
   if options.value then counter.value = tonumber(options.value) end
   if options.display then counter.display = options.display end
 end, "Sets the counter named by the <id> option to <value>; sets its display type (roman/Roman/arabic) to type <display>.")
 
 
-SILE.registerCommand("show-counter", function (options, _)
+SILE.registerCommand("show-counter", function (options, content)
   local counter = getCounter(options.id)
   if options.display then counter.display = options.display end
   SILE.typesetter:setpar(SILE.formatCounter(counter))
@@ -113,7 +111,7 @@ local function getMultilevelCounter(id)
   return counter
 end
 
-SILE.registerCommand("increment-multilevel-counter", function (options, _)
+SILE.registerCommand("increment-multilevel-counter", function (options, content)
   local counter = getMultilevelCounter(options.id)
   local currentLevel = #counter.value
   local level = tonumber(options.level) or currentLevel
@@ -136,7 +134,7 @@ SILE.registerCommand("increment-multilevel-counter", function (options, _)
   if options.display then counter.display[currentLevel] = options.display end
 end)
 
-SILE.registerCommand("show-multilevel-counter", function (options, _)
+SILE.registerCommand("show-multilevel-counter", function (options, content)
   local counter = getMultilevelCounter(options.id)
   if options.display then counter.display[#counter.value] = options.display end
 


### PR DESCRIPTION
Consists of two commits, I suggest to review them separately.

The main motivation for this was to expose a way to obtain a multilevel counter as string. While doing that, I have noticed an opportunity to cleanup some code duplication.

NOTE: It is pretty weird that `\show-(multilevel-)counter` commands can change the `display` of the counter permanently. Is that intentional or just a hack? It would be pretty easy to fix now.

Also, I am not sure about the exports and the `format` field on counters, as it duplicates the API. But it is IMO much nicer and easier to use. What do you think?