### PR TITLE
Add formats and Turkish language support to counters

### DIFF
--- a/core/utilities.lua
+++ b/core/utilities.lua
@@ -427,13 +427,6 @@ utilities.utf8_to_utf16le = function (str)
   return ustr
 end
 
-local romans = {
-  {1000, "M"},
-  {900, "CM"}, {500, "D"}, {400, "CD"}, {100, "C"},
-  {90, "XC"}, {50, "L"}, {40, "XL"}, {10, "X"},
-  {9, "IX"}, {5, "V"}, {4, "IV"}, {1, "I"}
-}
-
 local icu = require("justenoughicu")
 
 local icuFormats = function (format)
@@ -451,19 +444,6 @@ end
 -- see e.g. languages/tr.lua
 utilities.formatNumber = {
   und = {
-
-    roman = function (num)
-      local out = ""
-      num = num + 0
-      for _, v in ipairs(romans) do
-        val, let = unpack(v)
-        while num >= val do
-          num = num - val
-          out = out .. let
-        end
-      end
-      return out
-    end,
 
     alpha = function (num)
       local out = ""

--- a/languages/tr.lua
+++ b/languages/tr.lua
@@ -679,7 +679,11 @@ local tr_nums = function (num, ordinal)
   return table.concat(words, " ")
 end
 
-SILE.languageSupport.languages.tr = {
-  num2string = function(num) return tr_nums(num, false) end,
-  num2ordinal = function(num) return tr_nums(num, true) end
+SU.formatNumber.tr = {
+  string = function(num)
+    return tr_nums(num, false)
+  end,
+  ordinal = function (num)
+    return tr_nums(num, true)
+  end,
 }

--- a/languages/tr.lua
+++ b/languages/tr.lua
@@ -632,15 +632,18 @@ local sum_hundreds = function (val, loc, digits)
 end
 
 local tr_nums = function (num, ordinal)
+  if num >= 1e+36 then
+    SU.error("Numbers past decillions not supported in Turkish")
+  end
   local ordinal = SU.boolean(ordinal, false)
   local zero =  "sıfır"
   local ones = { "bir", "iki", "üç", "dört", "beş", "altı", "yedi", "sekiz", "dokuz" }
   local tens = { "on", "yirmi", "otuz", "kırk", "eli", "altmış", "yetmiş", "seksen", "doksan" }
-  local places = { "yüz", "bin", "milyon", "milyar", "trilyon" }
+  local places = { "yüz", "bin", "milyon", "milyar", "trilyon", "katrilyon", "kentilyon", "sekstilyon", "septilyon", "oktilyon", "nonilyon", "desilyon" }
   local zeroordinal = "sıfırıncı"
   local onesordinals = { "birinci", "ikinci", "üçüncü", "dördüncü", "beşinci", "altıncı", "yedinci", "sekizinci", "dokuzuncu" }
   local tensordinals = { "onuncu", "yirmiyinci", "otuzuncu", "kırkıncı", "eliyinci", "altmışıncı", "yetmişinci", "sekseninci", "Doksanıncı" }
-  local placesordinals = { "yüzüncü", "bininci", "milyonuncu", "milyarıncı", "trilyonuncu" }
+  local placesordinals = { "yüzüncü", "bininci", "milyonuncu", "milyarıncı", "trilyonuncu", "katrilyonuncu", "kentilyonuncu", "sekstilyonuncu", "septilyonuncu", "oktilyonuncu", "nonilyonuncu", "desilyonuncu" }
   local digits = string.reverse(num)
   local words = {}
   for i = 1, #digits do

--- a/packages/counters.lua
+++ b/packages/counters.lua
@@ -1,78 +1,8 @@
 if not SILE.scratch.counters then SILE.scratch.counters = {} end
 
-local textcase = SILE.require("packages/textcase").exports
 
-local romans = {
-  {1000, "M"},
-  {900, "CM"}, {500, "D"}, {400, "CD"}, {100, "C"},
-  {90, "XC"}, {50, "L"}, {40, "XL"}, {10, "X"},
-  {9, "IX"}, {5, "V"}, {4, "IV"}, {1, "I"}
-}
-
-local function num2roman(num)
-  local out = ""
-  num = num + 0
-  for _, v in ipairs(romans) do
-    val, let = unpack(v)
-    while num >= val do
-      num = num - val
-      out = out .. let
-    end
-  end
-  return out
-end
-
-local num2alpha = function (num)
-  local out = ""
-  local a = string.byte("a")
-  repeat
-    num = num - 1
-    out = string.char(num % 26 + a) .. out
-    num = (num - num % 26) / 26
-  until num < 1
-  return out
-end
-
-local icu = require("justenoughicu")
-
-SILE.formatCounter = function(counter)
-  local lang = SILE.settings.get("document.language")
-  local num2string, num2ordinal
-
-  local LS = SILE.languageSupport.languages[lang]
-  if LS then
-    if LS.formatCounter then
-      local result = LS.formatCounter(counter)
-      if result then return result end
-    end
-    num2alpha = LS.num2alpha and LS.num2alpha or num2alpha
-    num2roman = LS.num2roman and LS.num2roman or num2roman
-    num2string = LS.num2string and LS.num2string or num2string
-    num2ordinal = LS.num2ordinal and LS.num2ordinal or num2ordinal
-  end
-
-  -- If we have ICU, try that
-  if icu then
-    local display = counter.display
-    -- Translate numbering style names which are different in ICU
-    if display == "roman" then display = "romanlow"
-    elseif display == "Roman" then display = "roman"
-    end
-    local ok, result = pcall(function() return icu.format_number(counter.value, display) end)
-    if ok then return result end
-  end
-
-  if (counter.display == "string") and num2string then return textcase.lowercase(num2string(counter.value)) end
-  if (counter.display == "String") and num2string then return textcase.titlecase(num2string(counter.value)) end
-  if (counter.display == "STRING") and num2string then return textcase.uppercase(num2string(counter.value)) end
-  if (counter.display == "ordinal") and num2ordinal then return textcase.lowercase(num2ordinal(counter.value)) end
-  if (counter.display == "Ordinal") and num2ordinal then return textcase.titlecase(num2ordinal(counter.value)) end
-  if (counter.display == "ORDINAL") and num2ordinal then return textcase.uppercase(num2ordinal(counter.value)) end
-  if (counter.display == "roman") then return num2roman(counter.value):lower() end
-  if (counter.display == "Roman" or counter.display == "ROMAN") then return num2roman(counter.value) end
-  if (counter.display == "alpha") then return num2alpha(counter.value) end
-  if (counter.display == "Alpha" or counter.display =="ALPHA") then return textcase.uppercase(num2alpha(counter.value)) end
-  return tostring(counter.value)
+SILE.formatCounter = function (counter)
+  return SU.formatNumber(counter.value, counter.display)
 end
 
 local function getCounter(id)

--- a/packages/counters.lua
+++ b/packages/counters.lua
@@ -1,32 +1,33 @@
 if not SILE.scratch.counters then SILE.scratch.counters = {} end
-romans = {
+
+local romans = {
   {1000, "M"},
   {900, "CM"}, {500, "D"}, {400, "CD"}, {100, "C"},
   {90, "XC"}, {50, "L"}, {40, "XL"}, {10, "X"},
   {9, "IX"}, {5, "V"}, {4, "IV"}, {1, "I"}
 }
 
-local function romanize(k)
-  str = ""
-  k = k + 0
+local function num2roman(num)
+  local out = ""
+  num = num + 0
   for _, v in ipairs(romans) do
     val, let = unpack(v)
-    while k >= val do
-      k = k - val
-      str = str..let
+    while num >= val do
+      num = num - val
+      out = out .. let
     end
   end
-  return str
+  return out
 end
 
-local function alpha(n)
+local num2alpha = function (num)
   local out = ""
   local a = string.byte("a")
   repeat
-    n = n - 1
-    out = string.char(n%26 + a) .. out
-    n = (n - n%26)/26
-  until n < 1
+    num = num - 1
+    out = string.char(num % 26 + a) .. out
+    num = (num - num % 26) / 26
+  until num < 1
   return out
 end
 
@@ -34,31 +35,32 @@ local icu
 pcall( function () icu = require("justenoughicu") end)
 
 SILE.formatCounter = function(counter)
-  -- If there is a language-specific formatter, use that.
   local lang = SILE.settings.get("document.language")
-  if SILE.languageSupport.languages[lang] and SILE.languageSupport.languages[lang].counter then
-    local res = SILE.languageSupport.languages[lang].counter(counter)
-    if res then return res end -- allow them to pass.
+
+  local LS = SILE.languageSupport.languages[lang]
+  if LS then
+    if LS.formatCounter then
+      local result = LS.formatCounter(counter)
+      if result then return result end
+    end
+    local num2alpha = LS.num2alpha and LS.num2alpha or num2alpha
+    local num2roman = LS.num2roman and LS.num2roman or num2roman
   end
 
   -- If we have ICU, try that
   if icu then
     local display = counter.display
-
     -- Translate numbering style names which are different in ICU
-    if display == "roman" then
-      display = "romanlow"
-    elseif display == "Roman" then
-      display = "roman"
+    if display == "roman" then display = "romanlow"
+    elseif display == "Roman" then display = "roman"
     end
-
-    local ok, res = pcall(function() return icu.format_number(counter.value, display) end)
-    if ok then return res end
+    local ok, result = pcall(function() return icu.format_number(counter.value, display) end)
+    if ok then return result end
   end
 
-  if (counter.display == "roman") then return romanize(counter.value):lower() end
-  if (counter.display == "Roman") then return romanize(counter.value) end
-  if (counter.display == "alpha") then return alpha(counter.value) end
+  if (counter.display == "roman") then return num2roman(counter.value):lower() end
+  if (counter.display == "Roman") then return num2roman(counter.value) end
+  if (counter.display == "alpha") then return num2alpha(counter.value) end
   return tostring(counter.value)
 end
 

--- a/src/justenoughicu.c
+++ b/src/justenoughicu.c
@@ -191,7 +191,7 @@ int icu_canonicalize_language(lua_State *L) {
 
 int icu_format_number(lua_State *L) {
   double a = luaL_checknumber(L, 1);
-  /* See http://www.unicode.org/repos/cldr/tags/latest/common/bcp47/number.xml
+  /* See https://github.com/unicode-org/cldr/blob/master/common/bcp47/number.xml
      for valid system names */
   const char* system = luaL_checkstring(L, 2);
   char locale[18]; // "@numbers=12345678";

--- a/tests/counters.sil
+++ b/tests/counters.sil
@@ -1,15 +1,24 @@
-\begin[papersize=a5]{document}
+\begin[papersize=a6]{document}
+\nofolios
+\set[parameter=document.parindent,value=0pt]
+\font[family=Libertinus Serif]
 \script[src=packages/counters]
-
 \set-counter[id=test,value=1234]
-Standard counter: \show-counter[id=test]
 
-Roman counter: \show-counter[id=test,display=roman]
+Default: \show-counter[id=test]
 
-Greek counter: \show-counter[id=test,display=greklow]
+Alpha: \show-counter[id=test,display=alpha]
 
-Japanese counter: \font[family=Noto Sans CJK JP]{\show-counter[id=test,display=jpan]}
+Roman: \show-counter[id=test,display=ROMAN]
 
-Arabic counter: \font[family=Scheherazade]{\show-counter[id=test,display=arab]}
+Greek: \font[language=el]{\show-counter[id=test,display=greklow]}
+
+Japanese: \font[family=Noto Sans CJK JP,language=ja]{\show-counter[id=test,display=jpan]}
+
+Arabic-Indic: \font[family=Noto Naskh Arabic,language=ar]{\show-counter[id=test,display=arabext]}
+
+Turkish String: \font[language=tr]{\show-counter[id=test,display=String]}
+
+Turkish Ordinal: \font[language=tr]{\show-counter[id=test,display=Ordinal]}
 
 \end{document}


### PR DESCRIPTION
I'm working my way through things I wrote for CaSILE's `cabook` class and ran across the fact that I completely scrapped and replaced `SILE.formatCounter()`. These commits port most of the changes I made that still looked to me like improvements. My original only handled up to 4 digit numbers correctly, this has been extended up to 15 digits (Nine Hundred Ninety Nine Trillion...). I didn't know off the top of my head what comes after that in Turkish so I had to stop there. Both cardinal and ordinal output is supported.

```TeX
\set-counter[id=test,value=17264256543217]
\language[main=tr]{\show-counter[id=test,display=Ordinal]}
```
![image](https://user-images.githubusercontent.com/173595/58718326-f3056300-83d5-11e9-83ef-ce30bc636a86.png)

I will leave English and other languages as an exercsize for somebody else.