### PR TITLE
Autogenerate makefile dependencies

### DIFF
--- a/core/dummy-output.lua
+++ b/core/dummy-output.lua
@@ -1,0 +1,22 @@
+if (not SILE.outputters) then SILE.outputters = {} end
+
+local dummy = function() end
+
+SILE.outputters.dummy = {
+  init = dummy,
+  newPage = dummy,
+  finish = dummy,
+  setColor = dummy,
+  pushColor = dummy,
+  popColor = dummy,
+  outputHbox = dummy,
+  setFont = dummy,
+  drawImage = dummy,
+  imageSize = dummy,
+  moveTo = dummy,
+  rule = dummy,
+  debugFrame = dummy,
+  debugHbox = dummy
+}
+
+SILE.outputter = SILE.outputters.dummy

--- a/core/harfbuzz-shaper.lua
+++ b/core/harfbuzz-shaper.lua
@@ -63,6 +63,7 @@ SILE.shapers.harfbuzz = SILE.shapers.base {
     local face = fontconfig._face(opts)
     SU.debug("fonts", "Resolved font family '"..opts.family.."' -> "..(face and face.filename))
     if not face.filename then SU.error("Couldn't find face '"..opts.family.."'") end
+    if SILE.makeDeps then SILE.makeDeps:add(face.filename) end
     if bit32.rshift(face.index, 16) ~= 0 then
       SU.warn("GX feature in '"..opts.family.."' is not supported, fallback to regular font face.")
       face.index = bit32.band(face.index, 0xff)

--- a/core/makedeps.lua
+++ b/core/makedeps.lua
@@ -1,0 +1,34 @@
+local makeDeps = {
+  _deps = {},
+  add = function (self, file)
+    if not file and file ~= "nil" then return end
+    self._deps[file] = true
+  end,
+  write = function (self)
+    if type(self.filename) ~= "string" then
+      self.filename = SILE.masterFilename .. ".d"
+    end
+    for dep, _ in pairs(package.loaded) do
+      if dep ~= "_G" then
+        self:add(dep:gsub("%.", "/"))
+      end
+    end
+    local deps = {}
+    for dep, _ in pairs(self._deps) do
+      local resolvedFile = package.searchpath(dep, package.path, "/")
+      if not resolvedFile then resolvedFile = SILE.resolveFile(dep) end
+      if resolvedFile then
+        SU.debug("makedeps", "Resolved required file path", resolvedFile)
+        deps[#deps+1] = resolvedFile
+      else
+        -- SU.warn("Could not resolve dependency path for required file "..file)
+      end
+    end
+    table.sort(deps, function (a, b) return a < b end)
+    local depfile, err = io.open(self.filename, "w")
+    if not depfile then return SU.error(err) end
+    depfile:write(SILE.outputFilename..": "..table.concat(deps, " ").."\n")
+  end
+}
+
+return makeDeps

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -92,6 +92,7 @@ Options:
   -b, --backend=VALUE      choose an alternative output backend
   -d, --debug=VALUE        debug SILE's operation
   -e, --evaluate=VALUE     evaluate some Lua code before processing file
+  -m, --makedeps=[FILE]    generate a list of dependencies in Makefile format
   -o, --output=[FILE]      explicitly set output file name
   -I, --include=[FILE]     include a class or SILE file before processing input
   -t, --traceback          display detailed location trace on errors and warnings
@@ -122,6 +123,10 @@ Options:
       if err then SU.error(err) end
       SILE.dolua[#SILE.dolua+1] = func
     end
+  end
+  if opts.makedeps then
+    SILE.makeDeps = require("core.makedeps")
+    SILE.makeDeps.filename = opts.makedeps
   end
   if opts.output then
     SILE.outputFilename = opts.output
@@ -219,6 +224,7 @@ end
 
 -- Sort through possible places files could be
 function SILE.resolveFile(filename, pathprefix)
+  local resolved = nil
   local candidates = {}
   -- Start with the raw file name as given prefixed with a path if requested
   if pathprefix then candidates[#candidates+1] = std.io.catfile(pathprefix, filename) end
@@ -237,11 +243,11 @@ function SILE.resolveFile(filename, pathprefix)
   end
   -- Return the first candidate that exists, also checking the .sil suffix
   for _, v in pairs(candidates) do
-    if file_exists(v) then return v end
-    if file_exists(v..".sil") then return v .. ".sil" end
+    if file_exists(v) then resolved = v break end
+    if file_exists(v..".sil") then resolved = v..".sil" break end
   end
-  -- If we got here then no files existed even resembling the requested one
-  return nil
+  if SILE.makeDeps then SILE.makeDeps:add(resolved) end
+  return resolved
 end
 
 function SILE.call(command, options, content)
@@ -258,6 +264,12 @@ function SILE.call(command, options, content)
   local result = SILE.Commands[command](options, content)
   SILE.traceStack:pop(pId)
   return result
+end
+
+function SILE.finish ()
+  if SILE.makeDeps then
+    SILE.makeDeps:write()
+  end
 end
 
 return SILE

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -59,6 +59,9 @@ SILE.init = function ()
   elseif SILE.backend == "text" then
     require("core/harfbuzz-shaper")
     require("core/text-output")
+  elseif SILE.backend == "dummy" then
+    require("core/harfbuzz-shaper")
+    require("core/dummy-output")
   end
   if SILE.dolua then
     for _, func in pairs(SILE.dolua) do

--- a/core/sile.lua
+++ b/core/sile.lua
@@ -73,7 +73,7 @@ SILE.require = function (dependency, pathprefix)
   if file then return require(file:gsub(".lua$","")) end
   if pathprefix then
     local status, lib = pcall(require, std.io.catfile(pathprefix, dependency))
-    return status and lib or require(dependency)
+    if status then return lib end
   end
   return require(dependency)
 end

--- a/sile.in
+++ b/sile.in
@@ -21,7 +21,7 @@ if pathvar then
 	end
 end
 
-package.path = '?.lua;' .. package.path
+package.path = '?;?.lua' .. package.path
 
 package.cpath = package.cpath .. ";" ..
   "core/?."..SHARED_LIB_EXT.. ";" ..

--- a/sile.in
+++ b/sile.in
@@ -72,3 +72,5 @@ if SILE.masterFilename then
 else
   SILE.repl()
 end
+if SILE.makeDeps then SILE.makeDeps:add(debug.getinfo(1, "S").short_src) end
+SILE.finish()


### PR DESCRIPTION
Fixes #305.

This keeps track of every file used in the creation of a document including

* [x] system Lua libraries
* [x] SILE's internal vendor Lua libraies
* [x] SILE itself
* [x] SILE core and packages files
* [x] Font files when using harfbuzz (most backends)
* [ ] Font files when using pango
* [x] Document scripts and includes
* [x] Images

... and outputs them in a format that can be included into a GNU Makefile using the `-m` flag (with at optional filename).

Note this can be used with or without the dummy `-b dummy` backend that avoids writing any actual final output so dependencies can be generated on their own or as a side effect of the last rendering pass.