### PR TITLE
Disable serialized hyphenation pattern loading

### DIFF
--- a/core/languages.lua
+++ b/core/languages.lua
@@ -4,8 +4,8 @@ SILE.languageSupport = {
     if SILE.languageSupport.languages[language] then return end
     if SILE.hyphenator.languages[language] then return end
     if not(language) or language == "" then language = "en" end
-    ok, fail = pcall(function () SILE.require("languages/" .. language .. "-compiled") end)
-    if ok then return end
+    -- ok, fail = pcall(function () SILE.require("languages/" .. language .. "-compiled") end)
+    -- if ok then return end
     ok, fail = pcall(function () SILE.require("languages/" .. language) end)
     if fail then
       if fail:match("not found") then fail = "no support for this language" end


### PR DESCRIPTION
This is a hold over get get us through until a permanent fix for #633 is agreed on.

In my testing (over thousands of loads) simply disabling this "feature" reduces load time by 0.01-0.015 seconds and has no measurable effect on run time for a single document.

On the flip side, as long as this "feature" is enable the English language file is simply not doing its job at all.