### PR TITLE
test(tooling): Sketch out make targets to do basic performance regres…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,34 @@ examples: $(EXAMPLES)
 coverage: export SILE_COVERAGE=1
 coverage: test_previews
 
+HEADSHA ?= $(shell git rev-parse --short HEAD)
+BASESHA ?= $(shell git rev-parse --short $(HEADSHA)^)
+
+.PHONY: benchmark
+benchmark: time-$(HEADSHA).json time-$(BASESHA).json
+	cat $^
+
+time-%.json: benchmark-%/time.json
+	cp $< $@
+
+.PRECIOUS: benchmark-%/time.json
+benchmark-%/time.json: benchmark-%/sile
+	cd benchmark-$*
+	export TIMEFORMAT=$$'{ "real": "%R", "user": "%U", "sys": "%S" }'
+	{ time (./sile documentation/sile.sil > /dev/null 2>&1) } 2> time.json
+
+.PRECIOUS: benchmark-%/sile:
+benchmark-%/sile:
+	[[ -d benchmark-$* ]] || git worktree add --detach benchmark-$* $(HEADSHA)
+	cd benchmark-$*
+	[[ -d libtexpdf ]] && rmdir libtexpdf
+	[[ -h libtexpdf ]] || ln -s ../libtexpdf
+	[[ -h lua_modules ]] || ln -s ../lua_modules
+	[[ -h node_modules ]] || ln -s ../node_modules
+	./bootstrap.sh
+	./configure
+	make
+
 .PHONY: force
 force: ;
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,6 +84,14 @@ BASESHA ?= $(shell git rev-parse --short $(HEADSHA)^)
 benchmark: time-$(HEADSHA).json time-$(BASESHA).json
 	cat $^
 
+clean-recursive: clean-benchmarks
+
+.PHONY: clean-benchmarks
+clean-benchmarks:
+	rm -rf benchmark-*
+	git worktree prune
+	git branch --list | grep benchmark- | xargs git branch -D
+
 time-%.json: benchmark-%/time.json
 	cp $< $@
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,7 +6,7 @@ set -e
 # and we are part of a git repository that the user has not fully initialized,
 # go ahead and do the step of fetching the the submodule so the compile process
 # can run.
-if [ ! -f "libtexpdf/configure.ac" ] && [ -d ".git" ]; then
+if [ ! -f "libtexpdf/configure.ac" ] && [ -e ".git" ]; then
     git submodule update --init --recursive --remote
 fi
 


### PR DESCRIPTION
Here are some make targets to pit two revisions against each other in a raw feat of speed.

    # Test the current HEAD commit (note _not_ the working directory
    make benchmark

    # Test an arbitrary commit against it's parent
    make benchmark HEADSHA=ab461bca

    # Test any two arbitrary commits against eacho ther
    make benchmark HEADSHA=ab461bca BASESHA=b8c1e1c4

I should probably write a cleanup routine for the working trees created before this gets merged.