### PR TITLE
Add parallel frames for footnotes in layout

### DIFF
--- a/classes/diglot.lua
+++ b/classes/diglot.lua
@@ -49,6 +49,10 @@ function class:_init (options)
          left = "a",
          right = "b",
       },
+		ftn_frames = {
+			ftn_left = "c",
+			ftn_right = "d",
+		},
    })
 end
 


### PR DESCRIPTION
### What
Add two parallel frames under the main frames for typesetting footnotes.

### Why
To ensure a clear and consistent (fixed height) layout for footnotes, keeping them visually separated from the main content.

### How
- Registered two new parallel frames with the parallel package.
- Positioned the frames directly below the main parallel frames for vertical alignment.

### Testing
- Verified that the footnotes are correctly placed and aligned with the main frames.
- Manually inspected the output in various layout scenarios.

### Impact
- No breaking changes.
- Only affects documents with footnotes.
