### PR TITLE
refactor(types): Code cleaning and LDoc comments on node types

### DIFF
--- a/packages/tate/init.lua
+++ b/packages/tate/init.lua
@@ -112,7 +112,7 @@ function package:registerCommands ()
          SILE.settings:set("font.direction", "LTR")
          SILE.call("rotate", { angle = -90 }, function ()
             local hbox = SILE.call("hbox", {}, content)
-            hbox.misfit = true
+            hbox.orthogonal = true
             hbox.oldOutputYourself = hbox.outputYourself
             hbox.outputYourself = outputTateChuYoko
          end)

--- a/shapers/base.lua
+++ b/shapers/base.lua
@@ -153,19 +153,19 @@ function shaper:formNnode (contents, token, options)
    -- local glyphNames = {}
    local nnodeValue = { text = token, options = options, glyphString = {} }
    SILE.shaper:preAddNodes(contents, nnodeValue)
-   local misfit = false
+   local orthogonal = false
    if SILE.typesetter.frame and SILE.typesetter.frame:writingDirection() == "TTB" then
       if options.direction == "LTR" then
-         misfit = true
+         orthogonal = true
       end
    else
       if options.direction == "TTB" then
-         misfit = true
+         orthogonal = true
       end
    end
    for i = 1, #contents do
       local glyph = contents[i]
-      if (options.direction == "TTB") ~= misfit then
+      if (options.direction == "TTB") ~= orthogonal then
          if glyph.width > totalHeight then
             totalHeight = glyph.width
          end
@@ -186,7 +186,7 @@ function shaper:formNnode (contents, token, options)
       SILE.types.node.hbox({
          depth = totalDepth,
          height = totalHeight,
-         misfit = misfit,
+         orthogonal = orthogonal,
          width = SILE.types.length(totalWidth),
          value = nnodeValue,
       })
@@ -194,7 +194,7 @@ function shaper:formNnode (contents, token, options)
    return SILE.types.node.nnode({
       nodes = nnodeContents,
       text = token,
-      misfit = misfit,
+      orthogonal = orthogonal,
       options = options,
       language = options.language,
    })

--- a/types/node.lua
+++ b/types/node.lua
@@ -925,74 +925,23 @@ end
 
 -- DEPRECATED FUNCTIONS
 
-function box:isBox ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "hbox"
-      or self.type == "zerohbox"
-      or self.type == "alternative"
-      or self.type == "nnode"
-      or self.type == "vbox"
+local function _deprecated_isX ()
+   SU.deprecated("node:isX()", "is_X", "0.10.0", "0.16.0")
 end
 
-function box:isNnode ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "nnode"
-end
-
-function box:isGlue ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "glue"
-end
-
-function box:isVglue ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "vglue"
-end
-
-function box:isZero ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "zerohbox" or self.type == "zerovglue"
-end
-
-function box:isUnshaped ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "unshaped"
-end
-
-function box:isAlternative ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "alternative"
-end
-
-function box:isVbox ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "vbox"
-end
-
-function box:isInsertion ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "insertion"
-end
-
-function box:isMigrating ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.migrating
-end
-
-function box:isPenalty ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "penalty"
-end
-
-function box:isDiscretionary ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "discretionary"
-end
-
-function box:isKern ()
-   SU.warn("Deprecated function, please use boolean is_<type> property to check types", true)
-   return self.type == "kern"
-end
+box.isBox = _deprecated_isX
+box.isNnode = _deprecated_isX
+box.isGlue = _deprecated_isX
+box.isVglue = _deprecated_isX
+box.isZero = _deprecated_isX
+box.isUnshaped = _deprecated_isX
+box.isAlternative = _deprecated_isX
+box.isVbox = _deprecated_isX
+box.isInsertion = _deprecated_isX
+box.isMigrating = _deprecated_isX
+box.isPenalty = _deprecated_isX
+box.isDiscretionary = _deprecated_isX
+box.isKern = _deprecated_isX
 
 local _deprecated_nodefactory = {
    newHbox = true,

--- a/types/node.lua
+++ b/types/node.lua
@@ -33,7 +33,7 @@ box.type = "special"
 box.height = nil
 box.depth = nil
 box.width = nil
-box.misfit = false
+box.orthogonal = false
 box.explicit = false
 box.discardable = false
 box.value = nil
@@ -110,7 +110,7 @@ end
 --
 -- @treturn SILE.types.length  The width or height of the box, depending on the orientation.
 function box:lineContribution ()
-   return self.misfit and self.height or self.width
+   return self.orthogonal and self.height or self.width
 end
 
 --- Output routine for a box.

--- a/types/node.lua
+++ b/types/node.lua
@@ -4,8 +4,6 @@
 --
 -- @module SILE.types.node
 
-local nodetypes = {}
-
 -- This infinity needs to be smaller than an actual infinity but bigger than the infinite stretch
 -- added by the typesetter. See https://github.com/sile-typesetter/sile/issues/227
 local infinity = SILE.types.measurement(1e13)
@@ -96,7 +94,7 @@ end
 --
 -- @treturn box A new box with the same properties as the original, but with absolute dimensions.
 function box:absolute ()
-   local clone = nodetypes[self.type](self:_tospec())
+   local clone = self._class(self:_tospec())
    for dim in pairs(_dims) do
       clone[dim] = self[dim]:absolute()
    end
@@ -1022,25 +1020,27 @@ local _deprecated_nodefactory = {
 
 -- EXPORTS WRAP-UP
 
-nodetypes.box = box
-nodetypes.hbox = hbox
-nodetypes.zerohbox = zerohbox
-nodetypes.nnode = nnode
-nodetypes.unshaped = unshaped
-nodetypes.discretionary = discretionary
-nodetypes.alternative = alternative
-nodetypes.glue = glue
-nodetypes.hfillglue = hfillglue
-nodetypes.hssglue = hssglue
-nodetypes.kern = kern
-nodetypes.vglue = vglue
-nodetypes.vfillglue = vfillglue
-nodetypes.vssglue = vssglue
-nodetypes.zerovglue = zerovglue
-nodetypes.vkern = vkern
-nodetypes.penalty = penalty
-nodetypes.vbox = vbox
-nodetypes.migrating = migrating
+local nodetypes = {
+   box = box,
+   hbox = hbox,
+   zerohbox = zerohbox,
+   nnode = nnode,
+   unshaped = unshaped,
+   discretionary = discretionary,
+   alternative = alternative,
+   glue = glue,
+   hfillglue = hfillglue,
+   hssglue = hssglue,
+   kern = kern,
+   vglue = vglue,
+   vfillglue = vfillglue,
+   vssglue = vssglue,
+   zerovglue = zerovglue,
+   vkern = vkern,
+   penalty = penalty,
+   vbox = vbox,
+   migrating = migrating,
+}
 
 setmetatable(nodetypes, {
    __index = function (_, prop)


### PR DESCRIPTION
FWIW @alerque Some attempt at documenting and slightly reshuffling the code in `SILE.types.node`...

WIP as doing this, many comments popped up, I'll annotate the PR later, there's a lot of code smell that I'd like to sort out "file by file"