### PR TITLE
refactor(fonts,shapers): Cache font adjustment for efficiency

### DIFF
--- a/core/font.lua
+++ b/core/font.lua
@@ -12,42 +12,82 @@ local adjust_metric = P("ex-height") + P("cap-height")
 local adjustment = Ct(Cg(bits.number, "amount")^-1 * bits.ws * Cg(adjust_metric, "unit"))
 -- stylua: ignore end
 
-local function measureFontAdjustment (metric)
+--- Measure a font adjustment metric (ex-height or cap-height) for a given font options.
+-- @tparam string metric The metric to measure ("ex-height" or "cap-height")
+-- @tparam table fontoptions The font options to use
+local function measureFontAdjustment (metric, fontoptions)
    if metric == "ex-height" then
       -- Uses the height of lowercase letters.
       -- This is used to normalize lowercase letters across fonts.
       -- The height of the lowercase letter "x" is used as the reference.
       -- Another option would be to use the OS/2 font table sxHeight value when available.
-      return SILE.shaper:measureChar("x").height
+      return SILE.shaper:measureChar("x", fontoptions).height
    end
    if metric == "cap-height" then
       -- Uses the the height of uppercase letters.
       -- This is used to normalize uppercase letters across fonts.
       -- The height of the uppercase letter "H" is used as the reference.
       -- Another option would be to use the OS/2 font table sCapHeight value when available.
-      return SILE.shaper:measureChar("H").height
+      return SILE.shaper:measureChar("H", fontoptions).height
    end
    SU.error("Unknown font adjust metric " .. metric)
 end
 
+local _fontAdjustmentCache = {}
+local FONT_SIZE_FOR_ADJUSTMENT = 10 -- arbitrary size to measure adjustments
+
+--- Compute the adjusted font size based on an "adjust" option
+-- @tparam table options The font options, including the "adjust" field (in units of ex-height or cap-height)
+-- @treturn number The font size adjusted to the current font size
 local function adjustedFontSize (options)
    local adjust = options.adjust
    local parsed = adjustment:match(adjust)
    if not parsed then
       SU.error("Couldn't parse font adjust value " .. adjust)
    end
+   local ratio = parsed.amount or 1
+
+   -- We will adjust to the current font, but a neutral style, no variant, no features, no variations.
+   -- We assume the adjustment ratio between two fonts is not affected by the size, and only need
+   -- to be measured once per couple of fonts, for efficient caching.
+   -- The weight however is kept as it may affect the metrics, esp. if one of the fonts has some
+   -- weight unavailable in the other.
+   -- Variations are kept too, who knows if some axis may affect the ex-height/cap-height ratio...
+   local currentOptions = SILE.font.loadDefaults({
+      size = FONT_SIZE_FOR_ADJUSTMENT,
+      style = "",
+      variant = "normal",
+      features = "",
+   })
+   local currentKey = SILE.font._key(currentOptions)
+
    -- Shallow copy: we don't want to modify the original AST as content may be reused
    -- in other contexts (e.g. running headers) and may need to adapt to different font sizes.
    local baseOpts = pl.tablex.copy(options)
    baseOpts.adjust = nil -- cancel for target font size calculation
-   local currentMeasure = measureFontAdjustment(parsed.unit)
-   local ratio = parsed.amount or 1
-   local newMeasure
-   -- Apply the target font size to measure the new font
-   SILE.call("font", baseOpts, function ()
-      newMeasure = measureFontAdjustment(parsed.unit)
-   end)
-   return SILE.settings:get("font.size") * ratio * (currentMeasure / newMeasure)
+   baseOpts.size = FONT_SIZE_FOR_ADJUSTMENT
+   baseOpts.style = ""
+   baseOpts.variant = "normal"
+   baseOpts.features = ""
+   local newOptions = SILE.font.loadDefaults(baseOpts)
+   if newOptions.filename then
+      newOptions.family = nil
+   end
+   local newKey = SILE.font._key(newOptions)
+
+   local cacheKey = parsed.unit .. ":" .. currentKey .. ":" .. newKey
+   local adjustmentRatio = _fontAdjustmentCache[cacheKey]
+   if not adjustmentRatio then
+      local currentMeasure = measureFontAdjustment(parsed.unit, currentOptions)
+      local newMeasure
+      -- Apply the target font size to measure the new font
+      SILE.call("font", newOptions, function ()
+         newMeasure = measureFontAdjustment(parsed.unit, newOptions)
+      end)
+      adjustmentRatio = currentMeasure / newMeasure
+      _fontAdjustmentCache[cacheKey] = adjustmentRatio
+   end
+   return SILE.settings:get("font.size") * ratio * adjustmentRatio
 end
 
 SILE.registerCommand("font", function (options, content)

--- a/shapers/base.lua
+++ b/shapers/base.lua
@@ -89,8 +89,14 @@ function shaper:measureSpace (options)
    return shapespace(width and width.length or items[1].width)
 end
 
-function shaper:measureChar (char)
-   local options = SILE.font.loadDefaults({})
+--- Measure a single character.
+-- If options is not provided, the current font options are used.
+-- @tparam string char The character to measure
+-- @tparam[opt] table fontoptions Font options to use
+-- @treturn table A table with width, height and depth fields for each glyph in the character
+-- @treturn boolean Whether the character was found in the font
+function shaper:measureChar (char, fontoptions)
+   local options = fontoptions or SILE.font.loadDefaults({})
    options.tracking = SILE.settings:get("shaper.tracking")
    local items = self:shapeToken(char, options)
    if items and #items > 0 then


### PR DESCRIPTION
WIP experiment -- Saved as PR before I switch to other topics.

Font adjustment is a bit expensive - each time it is used, we activate the target font at the same size as the current font, shape an "x" or "H" for both to compute ex-height or cap-height, compute the ratio. If it wasn't used often, that would be okay, but with it being used for code, and possibly math, it gets invoked a lot (in documents with, obviously, either lots of "code"-formatted strings or lots of formulas).
That's a lot of repetitive small operations: (building near to identical options, loading fonts (C involved in the process), decoding fonts (shaper but also possibly Lua OT parsing, etc.), calling the shaper (C involved again), etc.

On my math booklet, this caching gain is however but a few seconds for an approx. 60 second build with a "heavy" math font (Garamond Math); and less noticeable with some other fonts (Libertinus Math or STIX Two Math)... So while interesting, it's perhaps not that decisive towards performance - i.e. there are lots of other performance costly operations in the whole process...

SILE already does a lot of font caching by a very narrow key in many places. But it's not clear to me how "ad hoc" the caching is, and it would seem we still perform a lot of operations without much clarity whether it is actually needed for good reasons... Surely that's something that could be questioned and clarified, for proper generalization.