### PR TITLE
Prefer fuller pages to less-full pages.

### DIFF
--- a/pagebuilders/base.lua
+++ b/pagebuilders/base.lua
@@ -111,7 +111,7 @@ function pagebuilder:findBestBreak (options)
          else
             c = badness
          end
-         if c < leastC then
+         if c <= leastC then
             leastC = c
             bestBreak = i
          else


### PR DESCRIPTION
When building pages and there are multiple options with the same lowest badness (for example, when there is at least one vfill inside the page, so all possible pages are badness 0), SILE will prefer the first possible break with that minimal badness. This doesn't match TeX's behavior, so I expect it is likely a bug.

My fix makes it take the last possible break with that minimum badness. This makes pages fuller and leads to less pathological behavior.